### PR TITLE
Fix PlayerContext imports

### DIFF
--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -6,7 +6,7 @@ import { doc, getDoc, collection, query, where, getDocs } from 'firebase/firesto
 import { db } from '@/lib/firebase';
 import { usePlayerStore } from '@/features/player/store';
 import { Button } from '@/components/ui/button';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import { normalizeTrack } from '@/utils/normalizeTrack';
 import { formatArtists } from '@/utils/formatArtists';
 import Image from 'next/image'; // Import Image from next/image
@@ -28,7 +28,9 @@ export default function AlbumPage() {
   const { albumId } = useParams();
   const [album, setAlbum] = useState<Album | null>(null);
   const [tracks, setTracks] = useState<Track[]>([]);
-  const { currentTrack, isPlaying, togglePlayPause } = usePlayer();
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const togglePlayPause = usePlayerStore((s) => s.togglePlayPause);
 
   useEffect(() => {
     console.log('AlbumPage albumId:', albumId); // Log albumId

--- a/src/app/artist/[artistId]/page.tsx
+++ b/src/app/artist/[artistId]/page.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { DiscAlbum, Music, MicVocal } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import BackButton from '@/components/ui/BackButton';
 
 export default function ArtistPage() {

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -6,7 +6,7 @@ import { collection, getDocs, query, orderBy, limit } from 'firebase/firestore';
 
 import { AlbumCard } from '@/components/AlbumCard';
 import SectionTitle from '@/components/SectionTitle';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 
 export default function DiscoverPage() {
   const [tracks, setTracks] = useState<Track[]>([]);

--- a/src/app/genre/[genre]/page.tsx
+++ b/src/app/genre/[genre]/page.tsx
@@ -11,12 +11,13 @@ import SectionTitle from '@/components/SectionTitle';
 import { AlbumCard } from '@/components/AlbumCard';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 
 export default function GenrePage() {
   const { genre } = useParams();
   const [tracks, setTracks] = useState<Track[]>([]);
-  const { playTrack, setQueue } = usePlayer();
+  const setQueue = usePlayerStore((s) => s.setQueue);
+  const setTrack = usePlayerStore((s) => s.setTrack);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -31,7 +32,7 @@ export default function GenrePage() {
   const handlePlayAll = () => {
     if (tracks.length > 0) {
       setQueue(tracks);
-      playTrack(tracks[0]);
+      setTrack(tracks[0]);
       toast({ title: 'Now Playing', description: `Genre: ${genre}` });
     }
   };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/toaster';
 import ClientLayout from '@/components/layout/ClientLayout';
 import { AuthProvider } from '@/contexts/AuthProvider';
-import { PlayerProvider } from '@/contexts/PlayerContext';
 
 const fontSans = Inter({
   subsets: ['latin'],
@@ -33,10 +32,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         )}
       >
         <AuthProvider>
-          <PlayerProvider>
-            <ClientLayout>{children}</ClientLayout>
-            <Toaster />
-          </PlayerProvider>
+          <ClientLayout>{children}</ClientLayout>
+          <Toaster />
         </AuthProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { collection, getDocs, query, orderBy } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import Section from '@/components/section';
 import Loader from '@/components/loader';
 import Link from 'next/link';

--- a/src/app/playlist/[playlistId]/page.tsx
+++ b/src/app/playlist/[playlistId]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { AlbumCard } from '@/components/AlbumCard';
 import SectionTitle from '@/components/SectionTitle';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import { PlayCircle, MoreVertical, ArrowLeft } from 'lucide-react';
 import EditPlaylistModal from '@/components/EditPlaylistModal';
 
@@ -24,7 +24,8 @@ export default function PlaylistDetailPage() {
   const { playlistId } = useParams();
   const { toast } = useToast();
   const router = useRouter();
-  const { setQueue, playTrack } = usePlayer();
+  const setQueue = usePlayerStore((s) => s.setQueue);
+  const setTrack = usePlayerStore((s) => s.setTrack);
   const [tracks, setTracks] = useState<Track[]>([]);
   const [playlistName, setPlaylistName] = useState('My Playlist');
 
@@ -54,7 +55,7 @@ export default function PlaylistDetailPage() {
   const handlePlayAll = () => {
     if (tracks.length === 0) return;
     setQueue(tracks);
-    playTrack(tracks[0]);
+    setTrack(tracks[0]);
     toast({ title: 'Now Playing', description: `Playlist: ${playlistName}` });
   };
 

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -6,7 +6,7 @@ import { collection, getDocs, getDoc, doc, query, orderBy, limit } from 'firebas
 
 import Top5Showcase from '@/components/Top5Showcase';
 import { db } from '@/lib/firebase';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,7 +7,7 @@ import SearchBar from '@/components/SearchBar';
 import FilterChip from '@/components/FilterChip';
 import SectionTitle from '@/components/SectionTitle';
 import { AlbumCard } from '@/components/AlbumCard';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import {
   Music,
   DiscAlbum,

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { CalendarDays, ListMusic, Info, PlayCircle } from 'lucide-react';
+import { usePlayerStore } from '@/features/player/store';
 import type { Track } from '@/types/music';
 import SectionTitle from '@/components/SectionTitle';
 import { Badge } from '@/components/ui/badge';
@@ -37,7 +38,7 @@ type Single = {
 
 export default function SingleDetailPage() {
   const params = useParams();
-  const { playTrack } = usePlayer();
+  const setTrack = usePlayerStore((s) => s.setTrack);
   const [single, setSingle] = useState<Single | null>(null);
   const [artistsDetails, setArtistsDetails] = useState<Artist[]>([]);
 
@@ -105,7 +106,7 @@ export default function SingleDetailPage() {
       return;
     }
 
-    playTrack(track);
+    setTrack(track);
   };
 
   if (!single) {
@@ -243,7 +244,9 @@ type TrackListItemProps = {
 };
 
 const TrackListItem = ({ track, onPlay, singleCoverURL }: TrackListItemProps) => {
-  const { currentTrack, isPlaying, togglePlayPause } = usePlayer();
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const togglePlayPause = usePlayerStore((s) => s.togglePlayPause);
   const isCurrent = currentTrack?.id === track.id;
 
   const handlePlayClick = (e: React.MouseEvent) => {
@@ -296,19 +299,4 @@ const TrackListItem = ({ track, onPlay, singleCoverURL }: TrackListItemProps) =>
     </div>
   );
 };
-function usePlayer(): {
-  playTrack: (track: Track) => void;
-  currentTrack: Track | null;
-  isPlaying: boolean;
-  togglePlayPause: (track: Track | null) => void;
-} {
-  // Replace this with your actual player store logic
-  // This is a placeholder implementation to avoid TypeScript errors
-  return {
-    playTrack: () => {},
-    currentTrack: null,
-    isPlaying: false,
-    togglePlayPause: () => {},
-  };
-}
 

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { RadioGroup } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import { useState, useEffect } from 'react';
 import { formatArtists } from '@/utils/formatArtists';
 import { saveLikedSong, isSongLiked } from '@/utils/saveLibraryData'; // Import utility functions

--- a/src/components/Top5Showcase.tsx
+++ b/src/components/Top5Showcase.tsx
@@ -1,7 +1,7 @@
 // src/components/Top5Showcase.tsx
 'use client';
 
-import { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import { AlbumCard } from '@/components/AlbumCard';
 
 interface Artist {

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -16,7 +16,8 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const router = useRouter();
 
   const { user, loading, logout } = useAuth();
-  const { currentTrack, isExpanded } = usePlayer();
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+  const isExpanded = usePlayerStore((s) => s.isExpanded);
 
   useEffect(() => {
     if (!loading && !user && pathname !== '/login') {

--- a/src/components/music/TrackActions.tsx
+++ b/src/components/music/TrackActions.tsx
@@ -9,7 +9,7 @@ import {
 import { MoreHorizontal, Heart, Plus, ListPlus, User, Disc } from 'lucide-react';
 import { usePlayerStore } from '@/features/player/store';
 import { useRouter } from 'next/navigation';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import AddToPlaylistModal from '@/components/playlists/AddToPlaylistModal';
 
 interface Props {
@@ -17,7 +17,8 @@ interface Props {
 }
 
 export default function TrackActions({ track }: Props) {
-  const { queue, setQueue } = usePlayer(); // Access queue and setQueue from usePlayer
+  const queue = usePlayerStore((s) => s.queue);
+  const setQueue = usePlayerStore((s) => s.setQueue);
   const router = useRouter();
 
   const handleAddToQueue = () => {

--- a/src/components/playlists/AddToPlaylistModal.tsx
+++ b/src/components/playlists/AddToPlaylistModal.tsx
@@ -13,7 +13,7 @@ import { useUser } from '@/hooks/useUser';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { collection, addDoc, getDocs, query, where } from 'firebase/firestore';
-import type { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 
 interface Props {
   trigger: React.ReactNode;

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Track } from '@/contexts/PlayerContext';
+import type { Track } from '@/types/music';
 import { AlbumCard as TrackCard } from '@/components/AlbumCard'; // or however you're displaying each track
 
 interface SectionProps {


### PR DESCRIPTION
## Summary
- remove obsolete `PlayerProvider`
- replace PlayerContext imports with store-based `usePlayerStore`
- update `Track` imports to use shared type

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: numerous TS errors)*
- `npm run format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c4fa4f48324a4690aff80015a1d