### PR TITLE
Implement Firestore search results

### DIFF
--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -12,3 +12,13 @@ export type Track = {
   artists: Artist[]; // Updated to support multiple artists
   type: string; // Required so all components agree
 };
+
+// A song is represented the same as a Track in most of the app
+export type Song = Track;
+
+export type Album = {
+  id: string;
+  title: string;
+  coverURL?: string;
+  artist?: string;
+};

--- a/src/utils/searchLibrary.ts
+++ b/src/utils/searchLibrary.ts
@@ -1,11 +1,12 @@
 // src/utils/searchLibrary.ts
 import { db } from '@/lib/firebase';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { collection, getDocs } from 'firebase/firestore';
+import type { Song, Album, Artist } from '@/types/music';
 
 interface SearchResults {
-  songs: any[];
-  albums: any[];
-  artists: any[];
+  songs: Song[];
+  albums: Album[];
+  artists: Artist[];
 }
 
 /**
@@ -15,39 +16,46 @@ interface SearchResults {
  * @returns A promise resolving to search results.
  */
 export async function searchLibrary(term: string): Promise<SearchResults> {
-  if (!term.trim()) {
+  const search = term.trim().toLowerCase();
+  if (!search) {
     return { songs: [], albums: [], artists: [] };
   }
 
   try {
-    // Query songs by title
-    const qSongs = query(
-      collection(db, 'songs'),
-      where('title', '>=', term),
-      where('title', '<=', term + '\uf8ff')
-    );
-    const songsSnapshot = await getDocs(qSongs);
-    const songs = songsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const [songsSnap, albumsSnap, artistsSnap] = await Promise.all([
+      getDocs(collection(db, 'songs')),
+      getDocs(collection(db, 'albums')),
+      getDocs(collection(db, 'artists')),
+    ]);
 
-    // Query albums by title
-    const qAlbums = query(
-      collection(db, 'albums'),
-      where('title', '>=', term),
-      where('title', '<=', term + '\uf8ff')
-    );
-    const albumsSnapshot = await getDocs(qAlbums);
-    const albums = albumsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const songs = songsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Song[];
+    const albums = albumsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Album[];
+    const artists = artistsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Artist[];
 
-    // Query artists by name
-    const qArtists = query(
-      collection(db, 'artists'),
-      where('name', '>=', term),
-      where('name', '<=', term + '\uf8ff')
-    );
-    const artistsSnapshot = await getDocs(qArtists);
-    const artists = artistsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+    const filteredSongs = songs.filter((s) => {
+      const title = (s as any).title || '';
+      const artist =
+        (s as any).artist ||
+        (Array.isArray((s as any).artists)
+          ? (s as any).artists.map((a: any) => a.name).join(' ')
+          : '');
+      const album = (s as any).album?.name || (s as any).album || '';
+      return (
+        title.toLowerCase().includes(search) ||
+        artist.toLowerCase().includes(search) ||
+        album.toLowerCase().includes(search)
+      );
+    });
 
-    return { songs, albums, artists };
+    const filteredAlbums = albums.filter((a) => {
+      const title = (a as any).title || '';
+      const artist = (a as any).artist || '';
+      return title.toLowerCase().includes(search) || artist.toLowerCase().includes(search);
+    });
+
+    const filteredArtists = artists.filter((a) => (a.name || '').toLowerCase().includes(search));
+
+    return { songs: filteredSongs, albums: filteredAlbums, artists: filteredArtists };
   } catch (error) {
     console.error('Error searching library:', error);
     return { songs: [], albums: [], artists: [] };


### PR DESCRIPTION
## Summary
- refactor Firestore search logic to fetch all items then filter
- expand type definitions for `Song` and `Album`
- update search page to show songs, albums and artists separately

## Testing
- `npm test`
- `npm run lint:fix` *(fails: ESLint couldn't find config)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683f7f21c1088324928401cb548a45f2