### PR TITLE
Implement Firebase admin upload

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /songs/{songId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.role == 'admin';
+    }
+    match /albums/{albumId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.role == 'admin';
+    }
+    match /artists/{artistId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.role == 'admin';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support comma-separated artists for admin upload
- create album docs and songs docs in Firestore
- auto-create missing artist documents
- add Firestore write rules restricting writes to admin users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f817120188324877cd17e9e1c15f4