### PR TITLE
Implement admin role checks

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -11,7 +11,10 @@ export function useUser() {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
-        const userDoc = await getDoc(doc(db, 'users', firebaseUser.uid));
+        let userDoc = await getDoc(doc(db, 'users', firebaseUser.uid));
+        if (!userDoc.exists()) {
+          userDoc = await getDoc(doc(db, 'profiles', firebaseUser.uid));
+        }
         setUser({
           uid: firebaseUser.uid,
           email: firebaseUser.email,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,2 @@
+export const ADMIN_EMAIL_DOMAIN = 'admin.com';
+export const ADMIN_EMAILS = ['angladea16@gmail.com'];


### PR DESCRIPTION
## Summary
- define admin emails/domain
- create missing Firestore profiles on auth state change
- ensure login/signup create profiles
- check both `users` and `profiles` collections when reading profile info

## Testing
- `npm run format`
- `npm run lint:fix` *(fails: ESLint couldn't find config)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f827a3e4c8324ad639ff722fbe85a