### PR TITLE
Fix artist data storage

### DIFF
--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -64,8 +64,8 @@ export default function AdminUploadPage() {
         let artistData;
         if (artistQuery.empty) {
           const newArtistRef = doc(collection(db, 'artists'));
-          artistData = { id: newArtistRef.id, name, createdAt: serverTimestamp() };
-          await setDoc(newArtistRef, artistData);
+          artistData = { id: newArtistRef.id, name };
+          await setDoc(newArtistRef, { ...artistData, createdAt: serverTimestamp() });
         } else {
           const docData = artistQuery.docs[0];
           artistData = { id: docData.id, name: docData.data().name };


### PR DESCRIPTION
## Summary
- avoid storing `createdAt` in local `artistsData`
- only add id and name to `artistsData` when creating artists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f84ba068883248a7058a0e7096f49