### PR TITLE
Fix TrackActions usage

### DIFF
--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -289,13 +289,7 @@ const TrackListItem = ({ track, onPlay, singleCoverURL }: TrackListItemProps) =>
           <div className="text-xs text-muted-foreground">{formatArtists(track.artists)}</div>
         </div>
       </div>
-      <TrackActions
-        track={{
-          ...track,
-          artist: track.artists,
-          coverURL: track.album?.coverURL || singleCoverURL || '/placeholder.png',
-        }}
-      />
+      <TrackActions track={track} />
     </div>
   );
 };

--- a/src/components/music/TrackActions.tsx
+++ b/src/components/music/TrackActions.tsx
@@ -55,12 +55,24 @@ export default function TrackActions({ track }: Props) {
           <Plus className="mr-2 size-4" />
           Add to Queue
         </DropdownMenuItem>
-        {track.artist && typeof track.artist === 'string' && (
-          <DropdownMenuItem onClick={() => router.push(`/artist/${track.artist}`)}>
-            <User className="mr-2 size-4" />
-            Go to Artist
-          </DropdownMenuItem>
-        )}
+        {Array.isArray(track.artists) && track.artists.length > 0
+          ? track.artists.map((artist) => (
+              <DropdownMenuItem
+                key={artist.id}
+                onClick={() => router.push(`/artist/${artist.id}`)}
+              >
+                <User className="mr-2 size-4" />
+                {artist.name ? `Go to ${artist.name}` : 'Go to Artist'}
+              </DropdownMenuItem>
+            ))
+          : track.artist && typeof track.artist === 'string' && (
+              <DropdownMenuItem
+                onClick={() => router.push(`/artist/${track.artist}`)}
+              >
+                <User className="mr-2 size-4" />
+                Go to Artist
+              </DropdownMenuItem>
+            )}
         {track.albumId && (
           <DropdownMenuItem onClick={() => router.push(`/album/${track.albumId}`)}>
             <Disc className="mr-2 size-4" />


### PR DESCRIPTION
## Summary
- pass track directly to TrackActions on single page
- update TrackActions component to handle `artists` list

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f84be5bfc8324894f1026b4a3bcfe