### PR TITLE
Fix search results type

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -48,18 +48,24 @@ export default function SearchPage() {
         }
 
         const querySnapshot = await getDocs(q);
-        const results = querySnapshot.docs.map((doc) => {
+        const results: Track[] = querySnapshot.docs.map((doc) => {
           const data = doc.data();
+
+          const artists = Array.isArray(data.artists)
+            ? data.artists
+            : data.artist
+              ? [{ id: data.artistId ?? '', name: data.artist }]
+              : [];
+
           return {
             id: doc.id,
             title: data.title || 'Untitled',
-            artist: data.artist || 'Unknown Artist',
-            imageURL: data.coverURL || '/placeholder.png',
-            coverURL: data.coverURL || '/placeholder.png',
             audioURL: data.audioURL || '',
-            duration: data.duration || 0,
+            coverURL: data.coverURL || '/placeholder.png',
+            artists,
+            album: data.album || null,
             type: activeType.toLowerCase(),
-          } as Track;
+          };
         });
 
         setSearchResults(results);


### PR DESCRIPTION
## Summary
- avoid casting search results to `Track`
- ensure artists array and album fields are populated

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails with missing module errors)*
- `npm run format:check` *(fails with formatting warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f84bb9b308324a4b6418314c2aa1f