### PR TITLE
Fix class order in QueueModal

### DIFF
--- a/src/features/player/QueueModal.tsx
+++ b/src/features/player/QueueModal.tsx
@@ -62,7 +62,7 @@ export default function QueueModal({ isOpen, onClose }: QueueModalProps) {
               </div>
 
               {/* Track Info */}
-              <div className="flex flex-col min-w-0">
+              <div className="min-w-0 flex flex-col">
                 <p className="truncate text-sm font-semibold">{track.title || 'Untitled'}</p>
                 <p className="truncate text-xs text-muted-foreground">
                   {formatArtists(track.artists)}


### PR DESCRIPTION
## Summary
- reorder Tailwind classes in `QueueModal`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f84c088348324940474be0c58842e