### PR TITLE
Consolidate Track types

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -3,42 +3,18 @@
 This file is auto-generated.
 
 ---
-### `src/app/album/[albumId]/page.tsx`
-- [7:10] 'usePlayerStore' is defined but never used. – `@typescript-eslint/no-unused-vars`
-
----
 ### `src/app/discover/page.tsx`
 - [49:14] Classname 'scrollbar-thumb-gray-400' is not a Tailwind CSS class! – `tailwindcss/no-custom-classname`
 - [49:14] Classname 'scrollbar-track-transparent' is not a Tailwind CSS class! – `tailwindcss/no-custom-classname`
 
 ---
-### `src/app/genre/[genre]/page.tsx`
-- [8:10] 'usePlayerStore' is defined but never used. – `@typescript-eslint/no-unused-vars`
-
----
 ### `src/app/login/page.tsx`
-- [32:6] React Hook useEffect has a missing dependency: 'router'. Either include it or remove the dependency array. – `react-hooks/exhaustive-deps`
-
----
-### `src/app/playlist/[playlistId]/page.tsx`
-- [9:10] 'usePlayerStore' is defined but never used. – `@typescript-eslint/no-unused-vars`
-
----
-### `src/app/single/[singleId]/page.tsx`
-- [42:26] 'setArtistsDetails' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-
----
-### `src/components/layout/ClientLayout.tsx`
-- [6:10] 'usePlayerStore' is defined but never used. – `@typescript-eslint/no-unused-vars`
+- [55:6] React Hook useEffect has a missing dependency: 'router'. Either include it or remove the dependency array. – `react-hooks/exhaustive-deps`
 
 ---
 ### `src/components/music/QueueModal.tsx`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
-
----
-### `src/components/music/TrackActions.tsx`
-- [10:10] 'usePlayerStore' is defined but never used. – `@typescript-eslint/no-unused-vars`
 
 ---
 ### `src/components/playlists/AddToPlaylistModal.tsx`
@@ -49,12 +25,8 @@ This file is auto-generated.
 - [27:23] Classname 'destructive' is not a Tailwind CSS class! – `tailwindcss/no-custom-classname`
 
 ---
-### `src/features/player/FullScreenPlayer.tsx`
-- [9:10] 'Progress' is defined but never used. – `@typescript-eslint/no-unused-vars`
-
----
 ### `src/features/player/MiniPlayer.tsx`
-- [76:12] Classnames 'left-0, right-0' could be replaced by the 'inset-x-0' shorthand! – `tailwindcss/enforces-shorthand`
+- [76:12] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 
 ---
 ### `src/features/player/QueueModal.tsx`

--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -96,7 +96,7 @@ export default function AlbumPage() {
           <div key={track.id} className="flex items-center justify-between">
             <div>
               <h3 className="text-sm font-semibold">{track.title}</h3>
-              <p className="text-xs text-muted-foreground">{formatArtists(track.artist)}</p>
+              <p className="text-xs text-muted-foreground">{formatArtists(track.artists)}</p>
             </div>
             <Button onClick={() => togglePlayPause(track)}>
               {currentTrack?.id === track.id && isPlaying ? 'Pause' : 'Play'}

--- a/src/app/artist/[artistId]/page.tsx
+++ b/src/app/artist/[artistId]/page.tsx
@@ -39,11 +39,11 @@ export default function ArtistPage() {
         albumSnap.docs.map((doc) => ({
           id: doc.id,
           title: doc.data().title || 'Untitled',
-          artist: doc.data().artist || decodedId,
+          artists: doc.data().artists || [{ id: '', name: doc.data().artist || decodedId }],
           genre: doc.data().genre || '',
           type: 'album' as const,
-          audioURL: '', // Provide default value for required Track property
-          coverURL: doc.data().coverURL || '', // Use imageUrl as coverURL
+          audioURL: '',
+          coverURL: doc.data().coverURL || '',
         }))
       );
 
@@ -54,11 +54,11 @@ export default function ArtistPage() {
         singleSnap.docs.map((doc) => ({
           id: doc.id,
           title: doc.data().title || 'Untitled',
-          artist: doc.data().artist || decodedId,
+          artists: doc.data().artists || [{ id: '', name: doc.data().artist || decodedId }],
           genre: doc.data().genre || '',
           type: 'track' as const,
-          audioURL: doc.data().audioURL || doc.data().audioSrc || '', // fallback to audioSrc if audioURL is missing
-          coverURL: doc.data().coverURL || doc.data().imageUrl || '', // fallback to imageUrl if coverURL is missing
+          audioURL: doc.data().audioURL || doc.data().audioSrc || '',
+          coverURL: doc.data().coverURL || doc.data().imageUrl || '',
         }))
       );
 
@@ -71,14 +71,14 @@ export default function ArtistPage() {
           return {
             id: doc.id,
             title: data.title || 'Untitled',
-            artist: data.artist || '',
+            artists: data.artists || [{ id: '', name: data.artist || '' }],
             genre: data.genre || '',
             type: 'track' as const,
             audioURL: data.audioURL || data.audioSrc || '',
             coverURL: data.coverURL || data.imageUrl || '',
           };
         })
-        .filter((track) => track.artist !== decodedId);
+        .filter((track) => !(track.artists[0]?.id === decodedId || track.artists[0]?.name === decodedId));
       setFeaturedTracks(filtered);
     };
 

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -22,9 +22,9 @@ export default function DiscoverPage() {
         return {
           id: doc.id,
           title: data.title,
-          artist: data.artist,
+          artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
           audioURL: data.audioURL,
-          coverURL: data.coverURL, // Required by <AlbumCard />
+          coverURL: data.coverURL,
           duration: data.duration,
           type: 'track',
         };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,9 +27,9 @@ export default function Home() {
           return {
             id: doc.id,
             title: data.title,
-            artist: data.artist,
+            artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
             audioURL: data.audioURL,
-            coverURL: data.coverURL, // required by Track interface
+            coverURL: data.coverURL,
             duration: data.duration || 0,
             type: 'track',
           };

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -53,7 +53,7 @@ export default function SearchPage() {
           return {
             id: doc.id,
             title: data.title || 'Untitled',
-            artist: data.artist || 'Unknown Artist',
+            artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
             imageURL: data.coverURL || '/placeholder.png',
             coverURL: data.coverURL || '/placeholder.png',
             audioURL: data.audioURL || '',

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -292,7 +292,6 @@ const TrackListItem = ({ track, onPlay, singleCoverURL }: TrackListItemProps) =>
       <TrackActions
         track={{
           ...track,
-          artist: track.artists,
           coverURL: track.album?.coverURL || singleCoverURL || '/placeholder.png',
         }}
       />

--- a/src/components/music/TrackActions.tsx
+++ b/src/components/music/TrackActions.tsx
@@ -55,8 +55,8 @@ export default function TrackActions({ track }: Props) {
           <Plus className="mr-2 size-4" />
           Add to Queue
         </DropdownMenuItem>
-        {track.artist && typeof track.artist === 'string' && (
-          <DropdownMenuItem onClick={() => router.push(`/artist/${track.artist}`)}>
+        {track.artists && track.artists.length > 0 && (
+          <DropdownMenuItem onClick={() => router.push(`/artist/${track.artists[0].id}`)}>
             <User className="mr-2 size-4" />
             Go to Artist
           </DropdownMenuItem>

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { db } from '@/lib/firebase';
 import { collection, getDocs } from 'firebase/firestore';
-import { Track } from '@/utils/helpers';
+import type { Track } from '@/types/music';
 
 export interface Album {
   id: string;
@@ -40,12 +40,16 @@ export function useLibrary() {
         return {
           id: doc.id,
           title: data.title || 'Untitled',
-          artist: data.artist || [{ id: '', name: 'Unknown Artist' }],
+          artists: data.artists || [{ id: '', name: 'Unknown Artist' }],
           audioURL: data.audioURL || '',
           coverURL: data.coverURL || '/placeholder.png',
           type: data.type || 'track',
           albumId: data.albumId || '',
-          album: data.album || { id: '', name: 'Unknown Album', coverURL: '/placeholder.png' },
+          album:
+            data.album ||
+            (data.albumId
+              ? { id: data.albumId, name: 'Unknown Album', coverURL: '/placeholder.png' }
+              : undefined),
           duration: data.duration || 0,
           trackNumber: data.trackNumber || 1,
           description: data.description || '',

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -3,14 +3,25 @@ export type Artist = {
   name: string;
 };
 
+export type AlbumInfo = {
+  id: string;
+  name: string;
+  coverURL: string;
+};
+
 export type Track = {
-  album: any;
   id: string;
   title: string;
+  artists: Artist[];
   audioURL: string;
   coverURL?: string;
-  artists: Artist[]; // Updated to support multiple artists
-  type: string; // Required so all components agree
+  type: string;
+  albumId?: string;
+  album?: AlbumInfo;
+  duration?: number;
+  trackNumber?: number;
+  description?: string;
+  dataAiHint?: string;
 };
 
 // A song is represented the same as a Track in most of the app

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 // src/utils/helpers.ts
+import type { Track } from '@/types/music';
 
 export function formatArtists(input: any): string {
   if (Array.isArray(input)) {
@@ -17,16 +18,18 @@ export function safeImageSrc(src: string | undefined | null): string {
 }
 
 export function normalizeTrack(raw: any): Track {
+  const artists = Array.isArray(raw.artists)
+    ? raw.artists.map((a: any) =>
+        typeof a === 'object' ? { id: a.id ?? '', name: a.name ?? '' } : { id: '', name: a ?? '' }
+      )
+    : raw.artist
+      ? [{ id: raw.artist.id ?? '', name: raw.artist.name ?? raw.artist }]
+      : [];
+
   return {
     id: raw.id,
     title: raw.title || 'Untitled',
-    artist: Array.isArray(raw.artists)
-      ? raw.artists.map((a: any) =>
-          typeof a === 'object' ? { id: a.id ?? '', name: a.name ?? '' } : { id: '', name: a ?? '' }
-        )
-      : raw.artist
-        ? [{ id: raw.artist.id ?? '', name: raw.artist.name ?? raw.artist }]
-        : [],
+    artists,
     audioURL: raw.audioURL || raw.audioUrl || '',
     coverURL: raw.coverURL || raw.coverUrl || '',
     duration: raw.duration || 0,
@@ -57,20 +60,4 @@ export function capitalize(str: string): string {
 export function getTrackRoute(item: { type: string; id: string }): string {
   const type = item.type?.toLowerCase();
   return type === 'album' ? `/album/${item.id}` : `/single/${item.id}`;
-}
-
-// Extend this if needed
-export interface Track {
-  id: string;
-  title: string;
-  artist: { id: string; name: string }[];
-  audioURL: string;
-  coverURL: string;
-  type: string;
-  albumId: string;
-  album: { id: string; name: string; coverURL: string };
-  duration: number;
-  trackNumber: number;
-  description?: string;
-  dataAiHint?: string;
 }


### PR DESCRIPTION
## Summary
- centralize `Track` definition in `src/types/music.ts`
- update helpers to use the unified type
- adjust TrackActions and pages to read `artists`
- migrate library hook to the new type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f84a70b948324adc104d95d509f4e