### PR TITLE
Improve playback and profile handling

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,5 +13,8 @@ service cloud.firestore {
       allow read: if true;
       allow write: if request.auth != null && request.auth.token.role == 'admin';
     }
+    match /profiles/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { collection, getDocs, getDoc, doc, query, orderBy, limit } from 'firebase/firestore';
+import { useAuth } from '@/contexts/AuthProvider';
 
 import Top5Showcase from '@/components/Top5Showcase';
 import { db } from '@/lib/firebase';
@@ -21,6 +22,7 @@ interface Artist {
 
 export default function ProfilePage() {
   const { userId } = useParams();
+  const { user } = useAuth();
   const [userProfile, setUserProfile] = useState<any>(null);
   const [topTracks, setTopTracks] = useState<Track[]>([]);
   const [topArtists, setTopArtists] = useState<Artist[]>([]);
@@ -31,7 +33,7 @@ export default function ProfilePage() {
       if (typeof userId !== 'string') return;
 
       // Fetch user profile
-      const profileSnap = await getDoc(doc(db, 'users', userId));
+      const profileSnap = await getDoc(doc(db, 'profiles', userId));
       if (profileSnap.exists()) {
         setUserProfile(profileSnap.data());
       }
@@ -79,12 +81,22 @@ export default function ProfilePage() {
     <div className="container mx-auto space-y-6 px-4 py-6">
       <div className="flex items-center justify-between">
         <SectionTitle>{userProfile?.displayName || 'User'}’s Profile</SectionTitle>
-        <Link
-          href="/library"
-          className="flex items-center gap-1 text-sm text-muted-foreground hover:underline"
-        >
-          <ArrowLeft size={16} /> Back
-        </Link>
+        <div className="flex gap-2">
+          {user?.uid === userId && (
+            <Link
+              href="/account"
+              className="text-sm text-muted-foreground hover:underline"
+            >
+              Edit Profile
+            </Link>
+          )}
+          <Link
+            href="/library"
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:underline"
+          >
+            <ArrowLeft size={16} /> Back
+          </Link>
+        </div>
       </div>
 
       <button

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -51,7 +51,12 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
                   Admin
                 </span>
               )}
-              <ProfileMenu isAuthenticated={!!user} userId={user.uid} onLogout={logout} />
+              <ProfileMenu
+                isAuthenticated={!!user}
+                userId={user.uid}
+                role={user.role as any}
+                onLogout={logout}
+              />
             </div>
           </div>
         </header>

--- a/src/components/layout/ProfileMenu.tsx
+++ b/src/components/layout/ProfileMenu.tsx
@@ -10,15 +10,24 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { UserCircle, Settings, LogOut, UserCog, LogIn, User as UserIcon } from 'lucide-react'; // Added UserIcon
+import {
+  UserCircle,
+  Settings,
+  LogOut,
+  UserCog,
+  LogIn,
+  User as UserIcon,
+  Upload,
+} from 'lucide-react';
 
 interface ProfileMenuProps {
   isAuthenticated: boolean;
   onLogout: () => void;
   userId?: string; // To link to the current user's profile
+  role?: 'admin' | 'artist' | 'listener';
 }
 
-export default function ProfileMenu({ isAuthenticated, onLogout, userId }: ProfileMenuProps) {
+export default function ProfileMenu({ isAuthenticated, onLogout, userId, role }: ProfileMenuProps) {
   // const user = { name: "Demo User", email: "demo@example.com" }; // Placeholder
 
   return (
@@ -59,6 +68,22 @@ export default function ProfileMenu({ isAuthenticated, onLogout, userId }: Profi
                 <span>Account Settings</span>
               </Link>
             </DropdownMenuItem>
+            {role === 'admin' && (
+              <DropdownMenuItem asChild>
+                <Link href="/admin/upload" className="flex cursor-pointer items-center hover:bg-accent/10">
+                  <Upload className="mr-2 size-4 text-primary" />
+                  <span>Admin Upload</span>
+                </Link>
+              </DropdownMenuItem>
+            )}
+            {role === 'artist' && (
+              <DropdownMenuItem asChild>
+                <Link href="/artist/${userId}" className="flex cursor-pointer items-center hover:bg-accent/10">
+                  <Upload className="mr-2 size-4 text-primary" />
+                  <span>Upload Music</span>
+                </Link>
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem asChild>
               <Link
                 href="/settings"

--- a/src/features/player/store.ts
+++ b/src/features/player/store.ts
@@ -20,6 +20,9 @@ type PlayerStore = {
   // Actions
   setTrack: (track: Track) => void;
   setQueue: (tracks: Track[]) => void;
+  setCurrentTrack: (track: Track | null) => void;
+  setIsPlaying: (val: boolean) => void;
+  addToQueue: (track: Track) => void;
   togglePlayPause: () => void;
   toggleExpand: () => void;
   setProgress: (val: number) => void;
@@ -57,6 +60,11 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       isPlaying: true,
     });
   },
+
+  setCurrentTrack: (track) => set({ currentTrack: track }),
+  setIsPlaying: (val) => set({ isPlaying: val }),
+
+  addToQueue: (track) => set((s) => ({ queue: [...s.queue, track] })),
 
   setQueue: (tracks) => {
     set({


### PR DESCRIPTION
## Summary
- extend player store with more actions
- update album and single pages to queue tracks and save to library
- create profile documents and allow editing from profile page
- add role-based menu options and secure Firestore rules
- show artist top songs on artist pages

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f942afc608324b09193cca9609b77