### PR TITLE
Update Firestore rules for liked songs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,5 +16,9 @@ service cloud.firestore {
     match /profiles/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+    // Allow users to read and manage their liked songs
+    match /users/{userId}/likedSongs/{songId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow authenticated users to read and write their liked songs documents

## Testing
- `npm run check:all` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_683f973a5d0c83249ce60fad9d7c8641