### PR TITLE
Implement profile and playback updates

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -6,10 +6,11 @@ import { useToast } from '@/hooks/use-toast';
 import { useRouter } from 'next/navigation';
 import { signOut } from 'firebase/auth';
 import { auth, db } from '@/lib/firebase';
-import { doc, updateDoc, getDoc } from 'firebase/firestore';
-import Link from 'next/link';
+import { doc, getDoc } from 'firebase/firestore';
+import { updateUserProfile } from '@/utils/user';
+import BackButton from '@/components/ui/BackButton';
 
-import { Camera, ArrowLeft } from 'lucide-react';
+import { Camera } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
@@ -36,7 +37,7 @@ export default function AccountPage() {
 
     const loadUserProfile = async () => {
       if (!user) return;
-      const profileRef = doc(db, 'users', user.uid);
+      const profileRef = doc(db, 'profiles', user.uid);
       const snapshot = await getDoc(profileRef);
 
       if (snapshot.exists()) {
@@ -58,8 +59,7 @@ export default function AccountPage() {
     if (!user) return;
 
     try {
-      const profileRef = doc(db, 'users', user.uid);
-      await updateDoc(profileRef, {
+      await updateUserProfile(user.uid, {
         displayName,
         email,
         bio,
@@ -96,12 +96,7 @@ export default function AccountPage() {
     <div className="container mx-auto space-y-6 px-4 py-6">
       <div className="flex items-center justify-between">
         <SectionTitle>Account</SectionTitle>
-        <Link
-          href="/library"
-          className="flex items-center gap-1 text-sm text-muted-foreground hover:underline"
-        >
-          <ArrowLeft size={16} /> Back
-        </Link>
+        <BackButton />
       </div>
 
       <div className="grid gap-6 md:grid-cols-3">

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -9,7 +9,7 @@ import Top5Showcase from '@/components/Top5Showcase';
 import { db } from '@/lib/firebase';
 import type { Track } from '@/types/music';
 
-import { ArrowLeft } from 'lucide-react';
+import BackButton from '@/components/ui/BackButton';
 import Link from 'next/link';
 import SectionTitle from '@/components/SectionTitle';
 
@@ -83,19 +83,11 @@ export default function ProfilePage() {
         <SectionTitle>{userProfile?.displayName || 'User'}’s Profile</SectionTitle>
         <div className="flex gap-2">
           {user?.uid === userId && (
-            <Link
-              href="/account"
-              className="text-sm text-muted-foreground hover:underline"
-            >
+            <Link href="/account" className="text-sm text-muted-foreground hover:underline">
               Edit Profile
             </Link>
           )}
-          <Link
-            href="/library"
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:underline"
-          >
-            <ArrowLeft size={16} /> Back
-          </Link>
+          <BackButton />
         </div>
       </div>
 

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -25,7 +25,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     }
   }, [loading, user, pathname, router]);
 
-  const hideNavRoutes = ['/login', '/account', '/settings'];
+  const hideNavRoutes = ['/login', '/account', '/settings', '/profile'];
   const showNav = user && !hideNavRoutes.some((path) => pathname.startsWith(path));
 
   if (loading) {

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,0 +1,29 @@
+import { auth, db } from '@/lib/firebase';
+import {
+  updateEmail,
+  updatePassword,
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+} from 'firebase/auth';
+import { doc, updateDoc } from 'firebase/firestore';
+
+export async function updateUserProfile(userId: string, updates: Record<string, any>) {
+  const ref = doc(db, 'profiles', userId);
+  await updateDoc(ref, updates);
+}
+
+export async function changeUserEmail(currentPassword: string, newEmail: string) {
+  const user = auth.currentUser;
+  if (!user || !user.email) throw new Error('Not authenticated');
+  const credential = EmailAuthProvider.credential(user.email, currentPassword);
+  await reauthenticateWithCredential(user, credential);
+  await updateEmail(user, newEmail);
+}
+
+export async function changeUserPassword(currentPassword: string, newPassword: string) {
+  const user = auth.currentUser;
+  if (!user || !user.email) throw new Error('Not authenticated');
+  const credential = EmailAuthProvider.credential(user.email, currentPassword);
+  await reauthenticateWithCredential(user, credential);
+  await updatePassword(user, newPassword);
+}


### PR DESCRIPTION
## Summary
- hide bottom nav on profile page
- connect account page to profiles collection
- add BackButton to profile and account pages
- add settings page for changing email/password
- update playback handlers on album and single detail pages
- introduce helper utilities for profile updates and credential changes

## Testing
- `npx prettier --write src/app/account/page.tsx src/app/profile/[userId]/page.tsx src/app/settings/page.tsx src/app/single/[singleId]/page.tsx src/app/album/[albumId]/page.tsx src/components/layout/ClientLayout.tsx src/utils/user.ts`
- `npm run typecheck` *(fails: Cannot find module 'firebase/app')*

------
https://chatgpt.com/codex/tasks/task_e_684053ac59788324ba8df10d9439031a