### PR TITLE
Project cleanup and nav logic fix

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -46,7 +46,7 @@ export default function DiscoverPage() {
 
       <section>
         <SectionTitle className="text-2xl">Newest Releases</SectionTitle>
-        <div className="scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent -mx-4 flex space-x-4 overflow-x-auto px-4 pb-4">
+        <div className="scrollbar-thin -mx-4 flex space-x-4 overflow-x-auto px-4 pb-4">
           {newestReleases.map((track) => (
             <AlbumCard key={track.id} item={track} className="w-36 shrink-0 sm:w-40 md:w-48" />
           ))}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -52,7 +52,7 @@ export default function LoginPage() {
     if (!authLoading && user) {
       router.push('/');
     }
-  }, [user, authLoading]);
+  }, [user, authLoading, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -25,8 +25,8 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     }
   }, [loading, user, pathname, router]);
 
-  const hideNavRoutes = ['/login', '/account', '/settings', '/profile'];
-  const showNav = user && !hideNavRoutes.some((path) => pathname.startsWith(path));
+  const tabRoutes = ['/', '/search', '/discover', '/library'];
+  const showNav = user && tabRoutes.includes(pathname);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- fix login redirection effect dependencies
- simplify discover scrollbar styles
- only show bottom tab bar on main routes
- remove obsolete queue modal file

## Testing
- `bash lint-check.sh` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68418f1884cc83248a390e898165bdad