### PR TITLE
Implement profile follow features

### DIFF
--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -2,16 +2,28 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { collection, getDocs, getDoc, doc, query, orderBy, limit } from 'firebase/firestore';
+import {
+  collection,
+  getDocs,
+  getDoc,
+  doc,
+  query,
+  orderBy,
+  limit,
+  updateDoc,
+} from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthProvider';
 
 import Top5Showcase from '@/components/Top5Showcase';
 import { db } from '@/lib/firebase';
 import type { Track } from '@/types/music';
+import { followUser, unfollowUser } from '@/utils/follow';
 
 import BackButton from '@/components/ui/BackButton';
 import Link from 'next/link';
 import SectionTitle from '@/components/SectionTitle';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 
 interface Artist {
   id: string;
@@ -26,7 +38,39 @@ export default function ProfilePage() {
   const [userProfile, setUserProfile] = useState<any>(null);
   const [topTracks, setTopTracks] = useState<Track[]>([]);
   const [topArtists, setTopArtists] = useState<Artist[]>([]);
-  const [showTop5, setShowTop5] = useState(true);
+  const [settings, setSettings] = useState({
+    showTopSongs: true,
+    showTopArtists: true,
+    showSpotlightPlaylists: true,
+  });
+  const [recentTracks, setRecentTracks] = useState<Track[]>([]);
+  const [followers, setFollowers] = useState(0);
+  const [following, setFollowing] = useState(0);
+  const [isFollowing, setIsFollowing] = useState(false);
+
+  const handleFollow = async () => {
+    if (!user || typeof userId !== 'string') return;
+    if (isFollowing) {
+      await unfollowUser(user.uid, userId);
+      setFollowers((f) => f - 1);
+    } else {
+      await followUser(user.uid, userId);
+      setFollowers((f) => f + 1);
+    }
+    setIsFollowing(!isFollowing);
+  };
+
+  const handleToggle = async (
+    key: 'showTopSongs' | 'showTopArtists' | 'showSpotlightPlaylists',
+    value: boolean,
+  ) => {
+    if (typeof userId !== 'string' || user?.uid !== userId) return;
+    const newSettings = { ...settings, [key]: value };
+    setSettings(newSettings);
+    await updateDoc(doc(db, 'profiles', userId), {
+      customizations: newSettings,
+    });
+  };
 
   useEffect(() => {
     const fetchProfileAndTop5 = async () => {
@@ -35,7 +79,21 @@ export default function ProfilePage() {
       // Fetch user profile
       const profileSnap = await getDoc(doc(db, 'profiles', userId));
       if (profileSnap.exists()) {
-        setUserProfile(profileSnap.data());
+        const data = profileSnap.data();
+        setUserProfile(data);
+        setSettings((prev) => ({
+          ...prev,
+          ...data.customizations,
+        }));
+      }
+
+      const followersSnap = await getDocs(collection(db, 'profiles', userId, 'followers'));
+      const followingSnap = await getDocs(collection(db, 'profiles', userId, 'following'));
+      setFollowers(followersSnap.size);
+      setFollowing(followingSnap.size);
+      if (user?.uid) {
+        const followDoc = await getDoc(doc(db, 'profiles', userId, 'followers', user.uid));
+        setIsFollowing(followDoc.exists());
       }
 
       // Fetch top 5 tracks
@@ -47,6 +105,14 @@ export default function ProfilePage() {
       const snapshot = await getDocs(top5TracksQuery);
       const tracks = snapshot.docs.map((doc) => doc.data() as Track);
       setTopTracks(tracks);
+
+      const recentQuery = query(
+        collection(db, 'users', userId, 'history'),
+        orderBy('lastPlayed', 'desc'),
+        limit(5)
+      );
+      const recentSnap = await getDocs(recentQuery);
+      setRecentTracks(recentSnap.docs.map((d) => d.data() as Track));
 
       // Generate top 5 artists from tracks
       const artistsMap = new Map<string, number>();
@@ -74,8 +140,8 @@ export default function ProfilePage() {
       setTopArtists(top5Artists);
     };
 
-    if (showTop5) fetchProfileAndTop5();
-  }, [userId, showTop5]);
+    fetchProfileAndTop5();
+  }, [userId]);
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-6">
@@ -91,19 +157,50 @@ export default function ProfilePage() {
         </div>
       </div>
 
-      <button
-        onClick={() => setShowTop5((prev) => !prev)}
-        className="text-sm text-muted-foreground hover:underline"
-      >
-        {showTop5 ? 'Hide Top 5' : 'Show Top 5'}
-      </button>
+      <div className="flex items-center gap-4">
+        <span className="text-sm">{followers} Followers</span>
+        <span className="text-sm">{following} Following</span>
+        {user && user.uid !== userId && (
+          <Button size="sm" onClick={handleFollow}>
+            {isFollowing ? 'Unfollow' : 'Follow'}
+          </Button>
+        )}
+      </div>
 
-      {showTop5 && (
-        <div className="space-y-8">
-          <Top5Showcase title="Top 5 Songs" items={topTracks} type="track" />
-          <Top5Showcase title="Top 5 Artists" items={topArtists} type="artist" />
+      {user?.uid === userId && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="showTopSongs"
+              checked={settings.showTopSongs}
+              onCheckedChange={(val) => handleToggle('showTopSongs', val)}
+            />
+            <label htmlFor="showTopSongs" className="text-sm">
+              Show Top Songs
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="showTopArtists"
+              checked={settings.showTopArtists}
+              onCheckedChange={(val) => handleToggle('showTopArtists', val)}
+            />
+            <label htmlFor="showTopArtists" className="text-sm">
+              Show Top Artists
+            </label>
+          </div>
         </div>
       )}
+
+      <div className="space-y-8">
+        {settings.showTopSongs && <Top5Showcase title="Top Songs" items={topTracks} type="track" />}
+        {settings.showTopArtists && (
+          <Top5Showcase title="Top Artists" items={topArtists} type="artist" />
+        )}
+        {recentTracks.length > 0 && (
+          <Top5Showcase title="Recently Played" items={recentTracks} type="track" />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/layout/BottomNavigationBar.tsx
+++ b/src/components/layout/BottomNavigationBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Home, Search, Compass, Library, Upload } from 'lucide-react';
+import { Home, Search, Compass, Library } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthProvider';
@@ -10,16 +10,12 @@ const BottomNavigationBar = () => {
   const pathname = usePathname();
   const { user } = useAuth();
 
-  const isAdmin = user?.role === 'admin';
-
   const navItems = [
     { href: '/', label: 'Home', icon: Home },
     { href: '/search', label: 'Search', icon: Search },
     { href: '/discover', label: 'Discover', icon: Compass },
     { href: '/library', label: 'Library', icon: Library },
   ];
-
-  const adminNavItems = [{ href: '/admin/upload', label: 'Upload', icon: Upload }];
 
   return (
     <nav className="fixed inset-x-0 bottom-0 z-40 flex h-16 items-center justify-around border-t border-border bg-card/80 shadow-xl backdrop-blur-md md:hidden">
@@ -41,28 +37,9 @@ const BottomNavigationBar = () => {
           </Link>
         </Button>
       ))}
-
-      {isAdmin &&
-        adminNavItems.map((item) => (
-          <Button
-            asChild
-            key={item.label}
-            variant="ghost"
-          className={`flex h-full flex-1 flex-col items-center justify-center rounded-lg p-2 transition-all ${
-              pathname === item.href
-                ? 'bg-primary/20 text-primary shadow-inner'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-            aria-current={pathname === item.href ? 'page' : undefined}
-          >
-            <Link href={item.href}>
-              <item.icon size={22} />
-              <span className="mt-0.5 text-xs">{item.label}</span>
-            </Link>
-          </Button>
-        ))}
-    </nav>
-  );
-};
+        {user && null /* upload tab removed */}
+      </nav>
+    );
+  };
 
 export default BottomNavigationBar;

--- a/src/components/layout/ProfileMenu.tsx
+++ b/src/components/layout/ProfileMenu.tsx
@@ -72,14 +72,6 @@ export default function ProfileMenu({ isAuthenticated, onLogout, userId, role }:
               <DropdownMenuItem asChild>
                 <Link href="/admin/upload" className="flex cursor-pointer items-center hover:bg-accent/10">
                   <Upload className="mr-2 size-4 text-primary" />
-                  <span>Admin Upload</span>
-                </Link>
-              </DropdownMenuItem>
-            )}
-            {role === 'artist' && (
-              <DropdownMenuItem asChild>
-                <Link href="/artist/${userId}" className="flex cursor-pointer items-center hover:bg-accent/10">
-                  <Upload className="mr-2 size-4 text-primary" />
                   <span>Upload Music</span>
                 </Link>
               </DropdownMenuItem>

--- a/src/utils/follow.ts
+++ b/src/utils/follow.ts
@@ -1,0 +1,18 @@
+import { db } from '@/lib/firebase';
+import { doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+
+export async function followUser(currentUserId: string, targetUserId: string) {
+  if (!currentUserId || !targetUserId || currentUserId === targetUserId) return;
+  const followerRef = doc(db, 'profiles', targetUserId, 'followers', currentUserId);
+  const followingRef = doc(db, 'profiles', currentUserId, 'following', targetUserId);
+  await setDoc(followerRef, { createdAt: serverTimestamp() });
+  await setDoc(followingRef, { createdAt: serverTimestamp() });
+}
+
+export async function unfollowUser(currentUserId: string, targetUserId: string) {
+  if (!currentUserId || !targetUserId || currentUserId === targetUserId) return;
+  const followerRef = doc(db, 'profiles', targetUserId, 'followers', currentUserId);
+  const followingRef = doc(db, 'profiles', currentUserId, 'following', targetUserId);
+  await deleteDoc(followerRef).catch(() => {});
+  await deleteDoc(followingRef).catch(() => {});
+}


### PR DESCRIPTION
## Summary
- restrict the upload action to the profile menu for admins only
- remove admin upload tab from the bottom navigation bar
- add follow/unfollow helpers for Firestore
- show follower counts and allow following on profile page
- let users toggle profile sections and persist settings

## Testing
- `npm test`
- `npx eslint@8 -c .eslintrc.cjs . --ext .ts,.tsx` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb0241c88324a9667d71f92bcbcd