### PR TITLE
Update saved albums path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,13 +18,18 @@ service cloud.firestore {
     }
 
     // Allow users to read their profile document under /users
-    match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
-
-      // Allow users to read and manage their liked songs
-      match /likedSongs/{songId} {
+      match /users/{userId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
+
+        // Allow users to read and manage their liked songs
+        match /likedSongs/{songId} {
+          allow read, write: if request.auth != null && request.auth.uid == userId;
+        }
+
+        // Allow users to manage their saved albums
+        match /savedAlbums/{albumId} {
+          allow read, write: if request.auth != null && request.auth.uid == userId;
+        }
       }
-    }
   }
 }

--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -97,7 +97,7 @@ export default function AlbumPage() {
   const handleAddToLibrary = async () => {
     const user = getAuth().currentUser;
     if (!user || !album) return;
-    await setDoc(doc(db, 'profiles', user.uid, 'savedAlbums', album.id), {
+    await setDoc(doc(db, 'users', user.uid, 'savedAlbums', album.id), {
       albumId: album.id,
       addedAt: serverTimestamp(),
     });


### PR DESCRIPTION
## Summary
- write saved albums under `/users/{uid}/savedAlbums` instead of `/profiles`
- allow read/write to saved albums in firestore rules

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1e6cc0c83248bf487fa1ab631b3