### PR TITLE
Add playlist security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,6 +17,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    // Allow users to manage playlists stored at the root
+    match /playlists/{playlistId} {
+      allow read, write: if request.auth != null && request.auth.uid == request.resource.data.ownerId;
+    }
+
     // Allow users to read their profile document under /users
       match /users/{userId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
@@ -28,6 +33,11 @@ service cloud.firestore {
 
         // Allow users to manage their saved albums
         match /savedAlbums/{albumId} {
+          allow read, write: if request.auth != null && request.auth.uid == userId;
+        }
+
+        // Allow users to manage their playlists
+        match /playlists/{playlistId} {
           allow read, write: if request.auth != null && request.auth.uid == userId;
         }
       }


### PR DESCRIPTION
## Summary
- allow users to manage playlists in their user documents
- permit root playlists collection writes when ownerId matches

## Testing
- `npm test`
- `bash lint-check.sh` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6842f52bb32c83249339ac3cae2f7ce9