### PR TITLE
Fix references to artist property

### DIFF
--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -116,14 +116,19 @@ export default function ProfilePage() {
 
       // Generate top 5 artists from tracks
       const artistsMap = new Map<string, number>();
-      tracks.forEach((t) => {
-        if (Array.isArray(t.artist)) {
-          t.artist.forEach((artistObj) => {
-            const artistName = artistObj.name;
+      tracks.forEach((t: any) => {
+        const trackArtists = t.artists ?? t.artist;
+        if (Array.isArray(trackArtists)) {
+          trackArtists.forEach((artistObj: any) => {
+            const artistName =
+              typeof artistObj === 'string' ? artistObj : artistObj.name;
             artistsMap.set(artistName, (artistsMap.get(artistName) || 0) + 1);
           });
-        } else if (typeof t.artist === 'string') {
-          artistsMap.set(t.artist, (artistsMap.get(t.artist) || 0) + 1);
+        } else if (typeof trackArtists === 'string') {
+          artistsMap.set(
+            trackArtists,
+            (artistsMap.get(trackArtists) || 0) + 1
+          );
         }
       });
 

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -133,7 +133,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
       </div>
       <div className="p-3">
         <h3 className="truncate text-sm font-semibold">{item.title}</h3>
-        <p className="truncate text-xs text-muted-foreground">{formatArtists(item.artist)}</p>
+        <p className="truncate text-xs text-muted-foreground">{formatArtists(item.artists)}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- handle `artist` vs `artists` fields in profile page logic
- use correct property in AlbumCard

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6c31b0c83248dfb495caec7a414