### PR TITLE
Fix admin write access and single playback

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,22 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth.token.role == 'admin' ||
+             get(/databases/$(database)/documents/profiles/$(request.auth.uid)).data.role == 'admin' ||
+             get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+    }
     match /songs/{songId} {
       allow read: if true;
-      allow write: if request.auth != null && request.auth.token.role == 'admin';
+      allow write: if request.auth != null && isAdmin();
     }
     match /albums/{albumId} {
       allow read: if true;
-      allow write: if request.auth != null && request.auth.token.role == 'admin';
+      allow write: if request.auth != null && isAdmin();
     }
     match /artists/{artistId} {
       allow read: if true;
-      allow write: if request.auth != null && request.auth.token.role == 'admin';
+      allow write: if request.auth != null && isAdmin();
     }
     match /profiles/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId;

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -82,12 +82,19 @@ export default function SingleDetailPage() {
             }));
           }
 
-          // Normalize tracklist
-          const normalizedTracklist = Array.isArray(singleData.tracklist)
-            ? singleData.tracklist
-                .filter((track) => track && typeof track === 'object')
-                .map((track) => normalizeTrack(track, fetchedArtists))
-            : [];
+          // Normalize tracklist. If no tracklist exists, treat the document
+          // itself as a single track.
+          const normalizedTracklist =
+            Array.isArray(singleData.tracklist) && singleData.tracklist.length > 0
+              ? singleData.tracklist
+                  .filter((track) => track && typeof track === 'object')
+                  .map((track) => normalizeTrack(track, fetchedArtists))
+              : [
+                  normalizeTrack(
+                    { id: singleDocSnap.id, ...singleData },
+                    fetchedArtists,
+                  ),
+                ];
 
           // Store fetched artist details in state
           setArtistsDetails(fetchedArtists);

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -8,7 +8,13 @@ export default function BackButton() {
 
   return (
     <button
-      onClick={() => router.back()}
+      onClick={() => {
+        if (typeof window !== 'undefined' && window.history.length > 1) {
+          router.back();
+        } else {
+          router.push('/discover');
+        }
+      }}
       className="mb-4 flex items-center gap-2 text-sm text-muted-foreground transition hover:text-primary"
     >
       <ArrowLeft size={16} />


### PR DESCRIPTION
## Summary
- update Firestore rules with `isAdmin()` helper so admin role can be read from profile or users document
- ensure singles without tracklists can still be played
- make BackButton fall back to `/discover` when history is empty

## Testing
- `npm run lint:fix` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684307b3982483249a97edf65048afab