### PR TITLE
Implement search improvements and tracklist component

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,6 +10,10 @@ service cloud.firestore {
       allow read: if true;
       allow write: if request.auth != null && isAdmin();
     }
+    match /tracks/{trackId} {
+      allow read: if true;
+      allow write: if request.auth != null && isAdmin();
+    }
     match /albums/{albumId} {
       allow read: if true;
       allow write: if request.auth != null && isAdmin();
@@ -19,7 +23,8 @@ service cloud.firestore {
       allow write: if request.auth != null && isAdmin();
     }
     match /profiles/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read: if resource.data.isProfilePublic == true || request.auth != null && request.auth.uid == userId;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
 
     // Allow users to manage playlists stored at the root

--- a/scripts/massDeleteSongs.js
+++ b/scripts/massDeleteSongs.js
@@ -1,0 +1,17 @@
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import serviceAccount from '../service-account.json' assert { type: 'json' };
+
+initializeApp({ credential: cert(serviceAccount as any) });
+
+const db = getFirestore();
+
+async function deleteAllSongs() {
+  const snap = await db.collection('songs').get();
+  const batch = db.batch();
+  snap.docs.forEach((d) => batch.delete(d.ref));
+  await batch.commit();
+  console.log(`Deleted ${snap.size} songs`);
+}
+
+deleteAllSongs().catch((err) => console.error(err));

--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import type { Track } from '@/types/music';
 import { normalizeTrack } from '@/utils/normalizeTrack';
-import { formatArtists } from '@/utils/formatArtists';
+import TrackListItem from '@/components/music/TrackListItem';
 import Image from 'next/image'; // Import Image from next/image
 
 interface Album {
@@ -132,22 +132,14 @@ export default function AlbumPage() {
         </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="space-y-1">
         {tracks.map((track) => (
-          <div key={track.id} className="flex items-center justify-between">
-            <div>
-              <h3 className="text-sm font-semibold">{track.title}</h3>
-              <p className="text-xs text-muted-foreground">{formatArtists(track.artists)}</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">
-                {track.duration ? formatTime(track.duration) : ''}
-              </span>
-              <Button onClick={() => handlePlay(track)}>
-                {currentTrack?.id === track.id && isPlaying ? 'Pause' : 'Play'}
-              </Button>
-            </div>
-          </div>
+          <TrackListItem
+            key={track.id}
+            track={track}
+            onPlay={handlePlay}
+            coverURL={album.coverURL}
+          />
         ))}
       </div>
     </div>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -13,7 +13,7 @@ export default function DiscoverPage() {
 
   useEffect(() => {
     async function fetchTracks() {
-      const tracksRef = collection(db, 'tracks');
+      const tracksRef = collection(db, 'songs');
       const q = query(tracksRef, orderBy('createdAt', 'desc'), limit(20));
       const snapshot = await getDocs(q);
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,12 +29,13 @@ export default function SearchPage() {
     songs: Track[];
     albums: Album[];
     artists: Artist[];
-  }>({ songs: [], albums: [], artists: [] });
+    users: { id: string; displayName: string; avatarURL?: string }[];
+  }>({ songs: [], albums: [], artists: [], users: [] });
 
   useEffect(() => {
     const fetchResults = async () => {
       if (!searchTerm.trim()) {
-        setSearchResults({ songs: [], albums: [], artists: [] });
+        setSearchResults({ songs: [], albums: [], artists: [], users: [] });
         return;
       }
 
@@ -44,6 +45,7 @@ export default function SearchPage() {
         songs: results.songs.map((song: Song) => normalizeTrack(song)),
         albums: results.albums,
         artists: results.artists,
+        users: results.users,
       });
     };
 
@@ -143,9 +145,29 @@ export default function SearchPage() {
           </div>
         )}
 
+        {(activeType === 'All' || activeType === 'Users') && searchResults.users.length > 0 && (
+          <div className="mt-4 space-y-2">
+            <SectionTitle className="text-xl">Users</SectionTitle>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 md:gap-6 lg:grid-cols-4">
+              {searchResults.users.map((u) => (
+                <Link key={u.id} href={`/profile/${u.id}`} legacyBehavior>
+                  <Card className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:bg-card/80">
+                    <Avatar>
+                      <AvatarImage src={u.avatarURL} alt={u.displayName} />
+                      <AvatarFallback>{u.displayName?.[0]?.toUpperCase()}</AvatarFallback>
+                    </Avatar>
+                    <span className="font-medium">{u.displayName}</span>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
         {searchResults.songs.length === 0 &&
           searchResults.albums.length === 0 &&
           searchResults.artists.length === 0 &&
+          searchResults.users.length === 0 &&
           (searchTerm || activeType !== 'All') && (
             <p className="py-8 text-center text-muted-foreground">
               No results found for &quot;{searchTerm}&quot;{' '}

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import BackButton from '@/components/ui/BackButton';
 import TrackActions from '@/components/music/TrackActions';
+import TrackListItem from '@/components/music/TrackListItem';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   doc,
@@ -26,7 +27,6 @@ import {
 import { getAuth } from 'firebase/auth';
 import { db } from '@/lib/firebase';
 import { normalizeTrack } from '@/utils/normalizeTrack';
-import { formatArtists } from '@/utils/formatArtists';
 import { useToast } from '@/hooks/use-toast';
 
 type Artist = {
@@ -271,12 +271,7 @@ export default function SingleDetailPage() {
             <CardContent className="p-0">
               <div className="space-y-1">
                 {single.tracklist.map((track) => (
-                  <TrackListItem
-                    key={track.id}
-                    track={track}
-                    onPlay={handlePlayTrack}
-                    singleCoverURL={single.coverURL}
-                  />
+                  <TrackListItem key={track.id} track={track} onPlay={handlePlayTrack} coverURL={single.coverURL} />
                 ))}
               </div>
             </CardContent>
@@ -287,65 +282,3 @@ export default function SingleDetailPage() {
   );
 }
 
-type TrackListItemProps = {
-  track: Track;
-  onPlay: (track: Track) => void;
-  singleCoverURL: string;
-};
-
-const TrackListItem = ({ track, onPlay, singleCoverURL }: TrackListItemProps) => {
-  const currentTrack = usePlayerStore((s) => s.currentTrack);
-  const isPlaying = usePlayerStore((s) => s.isPlaying);
-  const togglePlayPause = usePlayerStore((s) => s.togglePlayPause);
-  const isCurrent = currentTrack?.id === track.id;
-
-  const handlePlayClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isCurrent) {
-      togglePlayPause();
-    } else {
-      onPlay(track);
-    }
-  };
-
-  return (
-    <div
-      className="group flex min-w-0 flex-1 cursor-pointer items-center gap-3 md:gap-4"
-      role="button"
-      tabIndex={0}
-      onClick={() => onPlay(track)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          onPlay(track);
-        }
-      }}
-      aria-label={`Play ${track.title}`}
-    >
-      <div className="flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={handlePlayClick}
-          aria-label={`Play ${track.title}`}
-        >
-          {isCurrent && isPlaying ? (
-            <PlayCircle size={20} className="text-primary" />
-          ) : (
-            <PlayCircle size={20} />
-          )}
-        </Button>
-        <div>
-          <div className="font-medium">{track.title}</div>
-          <div className="text-xs text-muted-foreground">{formatArtists(track.artists)}</div>
-        </div>
-      </div>
-      <TrackActions
-        track={{
-          ...track,
-          artists: track.artists,
-          coverURL: track.album?.coverURL || singleCoverURL || '/placeholder.png',
-        }}
-      />
-    </div>
-  );
-};

--- a/src/components/music/TrackListItem.tsx
+++ b/src/components/music/TrackListItem.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { PlayCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import TrackActions from './TrackActions';
+import { usePlayerStore } from '@/features/player/store';
+import type { Track } from '@/types/music';
+import { formatArtists } from '@/utils/formatArtists';
+
+export type TrackListItemProps = {
+  track: Track;
+  onPlay: (track: Track) => void;
+  coverURL?: string;
+};
+
+export default function TrackListItem({ track, onPlay, coverURL }: TrackListItemProps) {
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const togglePlayPause = usePlayerStore((s) => s.togglePlayPause);
+  const isCurrent = currentTrack?.id === track.id;
+
+  const handlePlayClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isCurrent) {
+      togglePlayPause();
+    } else {
+      onPlay(track);
+    }
+  };
+
+  return (
+    <div
+      className="group flex cursor-pointer items-center justify-between rounded px-2 py-1 transition hover:bg-muted"
+      role="button"
+      tabIndex={0}
+      onClick={() => onPlay(track)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onPlay(track);
+        }
+      }}
+      aria-label={`Play ${track.title}`}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={handlePlayClick} aria-label={`Play ${track.title}`}>
+          {isCurrent && isPlaying ? <PlayCircle size={20} className="text-primary" /> : <PlayCircle size={20} />}
+        </Button>
+        <div className="min-w-0">
+          <div className="truncate font-medium">{track.title}</div>
+          <div className="truncate text-xs text-muted-foreground">{formatArtists(track.artists)}</div>
+        </div>
+      </div>
+      <TrackActions
+        track={{ ...track, artists: track.artists, coverURL: track.album?.coverURL || coverURL || '/placeholder.png' }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expand `searchLibrary` to fetch public user profiles
- display users in Search page results
- add public profile and tracks read rules in Firestore
- fetch songs on Discover page for proper permissions
- centralize track list item component and use on album/single pages
- keep admin role synced from Firestore on login
- add helper script to mass delete songs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430c1b9a348324ae270607b9fcd310