### PR TITLE
Fix library placeholders and sync user data

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -9,10 +9,6 @@ This file is auto-generated.
 - [44:9] 'isPlaying' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
 
 ---
-### `src/app/profile/[userId]/page.tsx`
-- [149:6] React Hook useEffect has a missing dependency: 'user.uid'. Either include it or remove the dependency array. – `react-hooks/exhaustive-deps`
-
----
 ### `src/app/single/[singleId]/page.tsx`
 - [14:8] 'TrackActions' is defined but never used. – `@typescript-eslint/no-unused-vars`
 
@@ -31,10 +27,10 @@ This file is auto-generated.
 
 ---
 ### `src/features/player/MiniPlayer.tsx`
-- [76:12] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
+- [77:12] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 
 ---
 ### `src/features/player/QueueModal.tsx`
-- [65:20] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
+- [66:20] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -13,16 +12,14 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'placehold.co',
-        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'firebasestorage.googleapis.com',
         pathname: '/**',
       },
     ],
-  },
-};
-
-module.exports = {
-  images: {
-    domains: ['firebasestorage.googleapis.com'],
   },
 };
 

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -7,10 +7,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ListMusic, Heart, DiscAlbum, GanttChartSquare, Music, Loader } from 'lucide-react';
 import CreatePlaylistModal from '@/components/playlists/CreatePlaylistModal';
 import { useLibrary } from '@/hooks/useLibrary';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function LibraryPage() {
   const { library, loading, reloadLibrary } = useLibrary();
+  const [tab, setTab] = useState('playlists');
 
   const likedSongs = library?.likedSongs || [];
   const savedAlbums = library?.savedAlbums || [];
@@ -72,10 +73,16 @@ export default function LibraryPage() {
     <div className="container mx-auto space-y-8 p-4 md:p-6 lg:p-8">
       <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
         <SectionTitle className="mb-0">My Library</SectionTitle>
-        <CreatePlaylistModal onPlaylistCreated={reloadLibrary} />
+        {tab === 'playlists' && (
+          <CreatePlaylistModal onPlaylistCreated={reloadLibrary} />
+        )}
       </div>
 
-      <Tabs defaultValue="playlists" className="w-full">
+      <Tabs
+        defaultValue="playlists"
+        className="w-full"
+        onValueChange={(val) => setTab(val)}
+      >
         <TabsList className="mb-6 grid w-full grid-cols-3 border border-border bg-card md:grid-cols-6">
           <TabsTrigger value="playlists">Playlists</TabsTrigger>
           <TabsTrigger value="liked">Liked Songs</TabsTrigger>

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import {
   collection,
@@ -72,9 +72,8 @@ export default function ProfilePage() {
     });
   };
 
-  useEffect(() => {
-    const fetchProfileAndTop5 = async () => {
-      if (typeof userId !== 'string') return;
+  const fetchProfileAndTop5 = useCallback(async () => {
+    if (typeof userId !== 'string') return;
 
       // Fetch user profile
       const profileSnap = await getDoc(doc(db, 'profiles', userId));
@@ -143,10 +142,13 @@ export default function ProfilePage() {
         }));
 
       setTopArtists(top5Artists);
-    };
+  }, [userId, user]);
 
+  useEffect(() => {
     fetchProfileAndTop5();
-  }, [userId]);
+    window.addEventListener('profileChange', fetchProfileAndTop5);
+    return () => window.removeEventListener('profileChange', fetchProfileAndTop5);
+  }, [fetchProfileAndTop5]);
 
   return (
     <div className="container mx-auto space-y-6 px-4 py-6">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthProvider';
 import { useToast } from '@/hooks/use-toast';
 import { doc, getDoc } from 'firebase/firestore';
@@ -19,16 +19,20 @@ export default function SettingsPage() {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      if (!user) return;
-      const snap = await getDoc(doc(db, 'profiles', user.uid));
-      if (snap.exists()) {
-        setEmail(snap.data().email || user.email || '');
-      }
-    };
-    if (user) fetchProfile();
+  const fetchProfile = useCallback(async () => {
+    if (!user) return;
+    const snap = await getDoc(doc(db, 'profiles', user.uid));
+    if (snap.exists()) {
+      setEmail(snap.data().email || user.email || '');
+    }
   }, [user]);
+
+  useEffect(() => {
+    if (user) fetchProfile();
+    const handle = () => fetchProfile();
+    window.addEventListener('settingsChange', handle);
+    return () => window.removeEventListener('settingsChange', handle);
+  }, [user, fetchProfile]);
 
   const handleEmailChange = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -27,6 +27,7 @@ import {
 import { getAuth } from 'firebase/auth';
 import { db } from '@/lib/firebase';
 import { normalizeTrack } from '@/utils/normalizeTrack';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { useToast } from '@/hooks/use-toast';
 
 type Artist = {
@@ -102,7 +103,7 @@ export default function SingleDetailPage() {
           setSingle({
             id: singleDocSnap.id,
             title: singleData.title,
-            coverURL: singleData.coverURL || '/placeholder.png',
+            coverURL: singleData.coverURL || DEFAULT_COVER_URL,
             releaseDate: singleData.releaseDate,
             tracklist: normalizedTracklist,
             credits: singleData.credits || '',

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect } from 'react';
 import { formatArtists } from '@/utils/formatArtists';
 import { saveLikedSong, isSongLiked } from '@/utils/saveLibraryData'; // Import utility functions
 import { useUser } from '@/hooks/useUser';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 
 export function AlbumCard({ item, className }: { item: Track; className?: string }) {
   const router = useRouter();
@@ -84,7 +85,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
     >
       <div className="relative aspect-square">
         <Image
-          src={item.coverURL && item.coverURL !== '' ? item.coverURL : '/placeholder.png'}
+          src={item.coverURL && item.coverURL !== '' ? item.coverURL : DEFAULT_COVER_URL}
           alt={item.title}
           width={500}
           height={500}

--- a/src/components/music/TrackInfo.tsx
+++ b/src/components/music/TrackInfo.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Track } from '@/types/music';
 import { formatArtists } from '@/utils/formatArtists';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 
 export default function TrackInfo({ track }: { track: Track }) {
   return (
@@ -40,7 +41,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
     >
       <div className="relative aspect-square">
         <Image
-          src={item.coverURL || '/placeholder.png'}
+          src={item.coverURL || DEFAULT_COVER_URL}
           alt={item.title}
           width={500}
           height={500}
@@ -69,7 +70,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
     >
       <div className="relative aspect-square">
         <Image
-          src={item.coverURL || '/placeholder.png'}
+          src={item.coverURL || DEFAULT_COVER_URL}
           alt={item.title}
           width={500}
           height={500}

--- a/src/components/music/TrackListItem.tsx
+++ b/src/components/music/TrackListItem.tsx
@@ -6,6 +6,7 @@ import TrackActions from './TrackActions';
 import { usePlayerStore } from '@/features/player/store';
 import type { Track } from '@/types/music';
 import { formatArtists } from '@/utils/formatArtists';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 
 export type TrackListItemProps = {
   track: Track;
@@ -51,7 +52,11 @@ export default function TrackListItem({ track, onPlay, coverURL }: TrackListItem
         </div>
       </div>
       <TrackActions
-        track={{ ...track, artists: track.artists, coverURL: track.album?.coverURL || coverURL || '/placeholder.png' }}
+        track={{
+          ...track,
+          artists: track.artists,
+          coverURL: track.album?.coverURL || coverURL || DEFAULT_COVER_URL,
+        }}
       />
     </div>
   );

--- a/src/components/playlists/CreatePlaylistModal.tsx
+++ b/src/components/playlists/CreatePlaylistModal.tsx
@@ -15,6 +15,7 @@ import { PlusCircle } from 'lucide-react';
 import { useUser } from '@/hooks/useUser';
 import { toast } from '@/hooks/use-toast';
 import { savePlaylist } from '@/utils/saveLibraryData';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 
 interface CreatePlaylistModalProps {
   onPlaylistCreated?: () => void;
@@ -40,7 +41,7 @@ export default function CreatePlaylistModal({ onPlaylistCreated }: CreatePlaylis
         playlistData: {
           name: title,
           description,
-          imageUrl: coverImage || '/placeholder.png', // Default cover image
+          imageUrl: coverImage || DEFAULT_COVER_URL,
           songs: [], // Initialize with an empty songs array
           createdAt: new Date().toISOString(),
           ownerId: '',

--- a/src/features/player/FullScreenPlayer.tsx
+++ b/src/features/player/FullScreenPlayer.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Image from 'next/image';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { usePlayerStore } from './store';
 import { formatArtists } from '@/utils/formatArtists';
 import { formatTime } from '@/lib/utils';
@@ -94,7 +95,7 @@ export default function FullScreenPlayer() {
       <div className="my-auto flex flex-col items-center gap-4 md:gap-6">
         <div className="group relative size-60 overflow-hidden rounded-xl shadow-2xl shadow-primary/30 sm:size-72 md:size-80">
           <Image
-            src={currentTrack.coverURL || '/placeholder.png'}
+            src={currentTrack.coverURL || DEFAULT_COVER_URL}
             alt={currentTrack.title || 'Unknown Track'}
             fill
             className="object-cover transition-transform duration-500 group-hover:scale-105"

--- a/src/features/player/MiniPlayer.tsx
+++ b/src/features/player/MiniPlayer.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { usePlayerStore } from './store';
 import { formatArtists } from '@/utils/formatArtists';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { Play, Pause } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
 
@@ -44,7 +45,7 @@ export default function MiniPlayer() {
           }`}
         >
           <Image
-            src={currentTrack.coverURL || '/placeholder.png'}
+            src={currentTrack.coverURL || DEFAULT_COVER_URL}
             alt={currentTrack.title || 'Unknown Track'}
             fill
             className="object-cover"

--- a/src/features/player/QueueModal.tsx
+++ b/src/features/player/QueueModal.tsx
@@ -3,6 +3,7 @@
 import { usePlayerStore } from './store';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import Image from 'next/image';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { formatArtists } from '@/utils/formatArtists';
 import { X } from 'lucide-react';
 import { Track } from '@/types/music';
@@ -53,7 +54,7 @@ export default function QueueModal({ isOpen, onClose }: QueueModalProps) {
               {/* Thumbnail */}
               <div className="relative size-12 overflow-hidden rounded-md shadow-md">
                 <Image
-                  src={track.coverURL || '/placeholder.png'}
+                  src={track.coverURL || DEFAULT_COVER_URL}
                   alt={track.title || 'Unknown Track'}
                   fill
                   className="object-cover"

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@/hooks/useUser';
 import { db } from '@/lib/firebase';
 import { collection, getDocs } from 'firebase/firestore';
+import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import type { Track } from '@/types/music';
 
 export interface Album {
@@ -49,13 +50,13 @@ export function useLibrary() {
           title: data.title || 'Untitled',
           artists: data.artists || [{ id: '', name: 'Unknown Artist' }],
           audioURL: data.audioURL || '',
-          coverURL: data.coverURL || '/placeholder.png',
+          coverURL: data.coverURL || DEFAULT_COVER_URL,
           type: data.type || 'track',
           albumId: data.albumId || '',
           album:
             data.album ||
             (data.albumId
-              ? { id: data.albumId, name: 'Unknown Album', coverURL: '/placeholder.png' }
+              ? { id: data.albumId, name: 'Unknown Album', coverURL: DEFAULT_COVER_URL }
               : undefined),
           duration: data.duration || 0,
           trackNumber: data.trackNumber || 1,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,10 @@
 // src/utils/helpers.ts
 import type { Track } from '@/types/music';
 
+// Default image used when a track or album is missing artwork
+export const DEFAULT_COVER_URL =
+  'https://placehold.co/500x500?text=No+Image';
+
 export function formatArtists(input: any): string {
   if (Array.isArray(input)) {
     return input
@@ -14,7 +18,7 @@ export function formatArtists(input: any): string {
 }
 
 export function safeImageSrc(src: string | undefined | null): string {
-  return src && src.trim() !== '' ? src : '/placeholder.png';
+  return src && src.trim() !== '' ? src : DEFAULT_COVER_URL;
 }
 
 export function normalizeTrack(raw: any): Track {

--- a/src/utils/normalizeTrack.ts
+++ b/src/utils/normalizeTrack.ts
@@ -1,5 +1,6 @@
 import type { Track } from '@/types/music';
 import { DocumentData } from 'firebase/firestore';
+import { DEFAULT_COVER_URL } from './helpers';
 
 export function normalizeTrack(
   doc: DocumentData,
@@ -17,7 +18,7 @@ export function normalizeTrack(
     artists: matchingArtists.length > 0 ? matchingArtists : [{ id: '', name: 'Unknown Artist' }],
 
     audioURL: data.audioURL || '',
-    coverURL: data.coverURL || '/placeholder.png',
+    coverURL: data.coverURL || DEFAULT_COVER_URL,
 
     type: data.type || 'single',
     albumId: data.albumId || '',
@@ -25,7 +26,7 @@ export function normalizeTrack(
       ? {
           id: data.album.id || '',
           name: data.album.name || 'Unknown Album',
-          coverURL: data.album.coverURL || '/placeholder.png',
+          coverURL: data.album.coverURL || DEFAULT_COVER_URL,
         }
       : undefined,
 

--- a/src/utils/saveLibraryData.ts
+++ b/src/utils/saveLibraryData.ts
@@ -18,6 +18,9 @@ export const saveLikedSong = async (
       trackId,
       likedAt: serverTimestamp(),
     });
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('libraryChange'));
+    }
   } catch (error) {
     console.error('Error saving liked song:', error);
   }
@@ -73,6 +76,9 @@ export const savePlaylist = async ({ userId, playlistData }: SavePlaylistParams)
       createdAt: playlistData.createdAt || serverTimestamp(), // Use provided timestamp or Firestore's server timestamp
       id: playlistId, // Include the generated playlist ID
     });
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('libraryChange'));
+    }
     console.info('Playlist saved successfully');
   } catch (error) {
     console.error('Error saving playlist:', error);
@@ -83,6 +89,9 @@ export const removeLikedSong = async (userId: string, trackId: string) => {
   const ref = doc(db, `users/${userId}/likedSongs`, trackId);
   try {
     await deleteDoc(ref);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('libraryChange'));
+    }
   } catch (error) {
     console.error('Error removing liked song:', error);
   }

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -10,6 +10,9 @@ import { doc, updateDoc } from 'firebase/firestore';
 export async function updateUserProfile(userId: string, updates: Record<string, any>) {
   const ref = doc(db, 'profiles', userId);
   await updateDoc(ref, updates);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('profileChange'));
+  }
 }
 
 export async function changeUserEmail(currentPassword: string, newEmail: string) {
@@ -18,6 +21,9 @@ export async function changeUserEmail(currentPassword: string, newEmail: string)
   const credential = EmailAuthProvider.credential(user.email, currentPassword);
   await reauthenticateWithCredential(user, credential);
   await updateEmail(user, newEmail);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('settingsChange'));
+  }
 }
 
 export async function changeUserPassword(currentPassword: string, newPassword: string) {
@@ -26,4 +32,7 @@ export async function changeUserPassword(currentPassword: string, newPassword: s
   const credential = EmailAuthProvider.credential(user.email, currentPassword);
   await reauthenticateWithCredential(user, credential);
   await updatePassword(user, newPassword);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('settingsChange'));
+  }
 }


### PR DESCRIPTION
## Summary
- update `next.config.ts` with unified image config
- add `DEFAULT_COVER_URL` helper and use everywhere
- reload library dynamically and hide playlist button unless needed
- propagate profile/settings changes via events
- auto-refresh account, settings and profile pages when data changes
- fix lint report

## Testing
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684320e052308324a7f9729328894274