### PR TITLE
Show global header and bottom navigation

### DIFF
--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -26,8 +26,6 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     }
   }, [loading, user, pathname, router]);
 
-  const tabRoutes = ['/', '/search', '/discover', '/library'];
-  const showNav = user && tabRoutes.includes(pathname);
 
   if (loading) {
     return (
@@ -38,15 +36,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   }
 
   const isAdmin = user?.role === 'admin';
+  const showLayout = user && pathname !== '/login';
 
   return (
     <div className="relative min-h-screen pb-28">
-      {user && (
+      {showLayout && (
         <header className="fixed inset-x-0 top-0 z-50 border-b border-border bg-background/75 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="container mx-auto flex items-center justify-between p-4">
             <SonixLogo className="h-8 w-auto" />
             <div className="flex items-center gap-4">
-              {/* Admin badge or link */}
               {isAdmin && (
                 <span className="rounded bg-yellow-200 px-2 py-1 text-xs font-semibold text-yellow-900">
                   Admin
@@ -54,8 +52,8 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
               )}
               <ProfileMenu
                 isAuthenticated={!!user}
-                userId={user.uid}
-                role={user.role as any}
+                userId={user?.uid}
+                role={user?.role as any}
                 onLogout={logout}
               />
             </div>
@@ -63,7 +61,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         </header>
       )}
 
-      <main className={`${user ? 'pt-20' : ''}`}>
+      <main className={showLayout ? 'pt-20' : ''}>
         {pathname === '/login' && !user
           ? React.cloneElement(children as React.ReactElement)
           : children}
@@ -71,7 +69,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
 
       {currentTrack && !isExpanded && <MiniPlayer />}
       {currentTrack && isExpanded && <FullScreenPlayer />}
-      {showNav && <BottomNavigationBar />}
+      {showLayout && <BottomNavigationBar />}
       <AudioProvider />
     </div>
   );


### PR DESCRIPTION
## Summary
- always render the profile header and bottom navigation bar
- update layout spacing accordingly
- hide header and bottom navigation on the login page

## Testing
- `npm run lint` *(fails: 4 errors, 6 warnings)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68432ce8959c832494ffed05614d2020