### PR TITLE
Fix player state handling

### DIFF
--- a/src/features/player/FullScreenPlayer.tsx
+++ b/src/features/player/FullScreenPlayer.tsx
@@ -8,7 +8,7 @@ import { formatArtists } from '@/utils/formatArtists';
 import { formatTime } from '@/lib/utils';
 import { Slider } from '@/components/ui/slider';
 import { Button } from '@/components/ui/button';
-import { ChevronDown, ListMusic, Shuffle, Repeat, Repeat1, VolumeX, Volume2, Play, Pause } from 'lucide-react';
+import { ChevronDown, ListMusic, Shuffle, Repeat, Repeat1, VolumeX, Volume2, Play, Pause, SkipForward, SkipBack } from 'lucide-react';
 
 export default function FullScreenPlayer() {
   const {
@@ -134,7 +134,7 @@ export default function FullScreenPlayer() {
           aria-label="Previous Track"
           className="text-muted-foreground hover:text-primary"
         >
-          <ChevronDown size={20} />
+          <SkipBack size={20} />
         </Button>
         <Button
           variant="ghost"
@@ -152,7 +152,7 @@ export default function FullScreenPlayer() {
           aria-label="Next Track"
           className="text-muted-foreground hover:text-primary"
         >
-          <ChevronDown size={20} />
+          <SkipForward size={20} />
         </Button>
       </div>
 

--- a/src/features/player/store.ts
+++ b/src/features/player/store.ts
@@ -58,10 +58,15 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       currentTrack: track,
       queueIndex: index >= 0 ? index : 0,
       isPlaying: true,
+      isExpanded: false,
     });
   },
 
-  setCurrentTrack: (track) => set({ currentTrack: track }),
+  setCurrentTrack: (track) =>
+    set({
+      currentTrack: track,
+      isExpanded: false,
+    }),
   setIsPlaying: (val) => set({ isPlaying: val }),
 
   addToQueue: (track) => set((s) => ({ queue: [...s.queue, track] })),
@@ -72,6 +77,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       queueIndex: 0,
       currentTrack: tracks[0] ?? null,
       isPlaying: !!tracks[0],
+      isExpanded: false,
     });
   },
 


### PR DESCRIPTION
## Summary
- reset player to mini-mode when selecting a track
- ensure queue initialization collapses the full player
- adjust skip icons in full screen player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684335e94fe88324a8ab4c42d39a172f