### PR TITLE
Fix lint errors in album and single pages

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -3,16 +3,6 @@
 This file is auto-generated.
 
 ---
-### `src/app/album/[albumId]/page.tsx`
-- [18:10] 'formatTime' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [43:9] 'currentTrack' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-- [44:9] 'isPlaying' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-
----
-### `src/app/single/[singleId]/page.tsx`
-- [14:8] 'TrackActions' is defined but never used. – `@typescript-eslint/no-unused-vars`
-
----
 ### `src/components/music/QueueModal.tsx`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`

--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -15,7 +15,6 @@ import {
 import { getAuth } from 'firebase/auth';
 import { db } from '@/lib/firebase';
 import { usePlayerStore } from '@/features/player/store';
-import { formatTime } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import type { Track } from '@/types/music';
@@ -40,8 +39,6 @@ export default function AlbumPage() {
   const { albumId } = useParams();
   const [album, setAlbum] = useState<Album | null>(null);
   const [tracks, setTracks] = useState<Track[]>([]);
-  const currentTrack = usePlayerStore((s) => s.currentTrack);
-  const isPlaying = usePlayerStore((s) => s.isPlaying);
   const setCurrentTrack = usePlayerStore((s) => s.setCurrentTrack);
   const setIsPlaying = usePlayerStore((s) => s.setIsPlaying);
   const setQueue = usePlayerStore((s) => s.setQueue);

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -11,7 +11,6 @@ import SectionTitle from '@/components/SectionTitle';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import BackButton from '@/components/ui/BackButton';
-import TrackActions from '@/components/music/TrackActions';
 import TrackListItem from '@/components/music/TrackListItem';
 import { Card, CardContent } from '@/components/ui/card';
 import {


### PR DESCRIPTION
## Summary
- remove unused `TrackActions` import in single page
- clean up unused imports and variables in album detail page
- update `FIXME.md` via pre-commit hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684336f4554c832497d5549aec009ceb