### PR TITLE
Fix library cover art display

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -9,7 +9,7 @@ This file is auto-generated.
 
 ---
 ### `src/components/playlists/AddToPlaylistModal.tsx`
-- [44:6] React Hook useEffect has an unnecessary dependency: 'toast'. Either exclude it or remove the dependency array. Outer scope values like 'toast' aren't valid dependencies because mutating them doesn't re-render the component. – `react-hooks/exhaustive-deps`
+- [43:6] React Hook useEffect has an unnecessary dependency: 'toast'. Either exclude it or remove the dependency array. Outer scope values like 'toast' aren't valid dependencies because mutating them doesn't re-render the component. – `react-hooks/exhaustive-deps`
 
 ---
 ### `src/components/ui/toast.tsx`

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -19,7 +19,7 @@ import { useState, useEffect } from 'react';
 import { formatArtists } from '@/utils/formatArtists';
 import { saveLikedSong, isSongLiked } from '@/utils/saveLibraryData'; // Import utility functions
 import { useUser } from '@/hooks/useUser';
-import { DEFAULT_COVER_URL } from '@/utils/helpers';
+import { getTrackRoute, safeImageSrc } from '@/utils/helpers';
 
 export function AlbumCard({ item, className }: { item: Track; className?: string }) {
   const router = useRouter();
@@ -28,12 +28,12 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
   const [selectedPlaylistId, setSelectedPlaylistId] = useState<string | null>(null);
   const [isFavorited, setIsFavorited] = useState(false);
 
-  // Determine type dynamically: "album" if albumId exists, otherwise "single"
-  const type = item.albumId ? 'album' : 'single';
+  // Determine type dynamically, falling back to album/single detection
+  const type = item.type || (item.albumId ? 'album' : 'single');
   const id = item.id;
 
   // Generate the href dynamically based on type and id
-  const href = `/${type}/${id}`;
+  const href = getTrackRoute({ type, id });
 
   // Fetch whether the song is liked
   useEffect(() => {
@@ -85,8 +85,8 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
     >
       <div className="relative aspect-square">
         <Image
-          src={item.coverURL && item.coverURL !== '' ? item.coverURL : DEFAULT_COVER_URL}
-          alt={item.title}
+          src={safeImageSrc(item.coverURL || (item as any).imageUrl)}
+          alt={item.title || (item as any).name}
           width={500}
           height={500}
           className="size-full rounded-t-xl object-cover"
@@ -133,8 +133,10 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
         </div>
       </div>
       <div className="p-3">
-        <h3 className="truncate text-sm font-semibold">{item.title}</h3>
-        <p className="truncate text-xs text-muted-foreground">{formatArtists(item.artists)}</p>
+        <h3 className="truncate text-sm font-semibold">{item.title || (item as any).name}</h3>
+        {item.artists && (
+          <p className="truncate text-xs text-muted-foreground">{formatArtists(item.artists)}</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/playlists/AddToPlaylistModal.tsx
+++ b/src/components/playlists/AddToPlaylistModal.tsx
@@ -12,7 +12,7 @@ import { db } from '@/lib/firebase';
 import { useUser } from '@/hooks/useUser';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
-import { collection, addDoc, getDocs, query, where } from 'firebase/firestore';
+import { collection, addDoc, getDocs } from 'firebase/firestore';
 import type { Track } from '@/types/music';
 
 interface Props {
@@ -29,9 +29,8 @@ export default function AddToPlaylistModal({ trigger, track }: Props) {
       if (!user?.uid) return;
 
       try {
-        // Query playlists where ownerId === user.uid
-        const playlistsQuery = query(collection(db, 'playlists'), where('ownerId', '==', user.uid));
-        const snap = await getDocs(playlistsQuery);
+        // Fetch playlists from the current user's subcollection
+        const snap = await getDocs(collection(db, 'users', user.uid, 'playlists'));
         const list = snap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
         setPlaylists(list);
       } catch (err) {

--- a/src/components/playlists/CreatePlaylistModal.tsx
+++ b/src/components/playlists/CreatePlaylistModal.tsx
@@ -39,7 +39,7 @@ export default function CreatePlaylistModal({ onPlaylistCreated }: CreatePlaylis
       await savePlaylist({
         userId: user.uid, // Pass the current user's ID
         playlistData: {
-          name: title,
+          title,
           description,
           imageUrl: coverImage || DEFAULT_COVER_URL,
           songs: [], // Initialize with an empty songs array

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -77,7 +77,15 @@ export function useLibrary() {
             };
           })
           .sort((a, b) => new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime()),
-        createdPlaylists: playlistsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() })),
+        createdPlaylists: playlistsSnap.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            title: data.title || data.name || 'Untitled',
+            coverURL: data.coverURL || data.imageUrl || DEFAULT_COVER_URL,
+            ...data,
+          };
+        }),
         genres: [], // Add logic for genres if needed
       });
     } catch (error) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -63,5 +63,6 @@ export function capitalize(str: string): string {
 
 export function getTrackRoute(item: { type: string; id: string }): string {
   const type = item.type?.toLowerCase();
+  if (type === 'playlist') return `/playlist/${item.id}`;
   return type === 'album' ? `/album/${item.id}` : `/single/${item.id}`;
 }

--- a/src/utils/saveLibraryData.ts
+++ b/src/utils/saveLibraryData.ts
@@ -43,7 +43,7 @@ export const isSongLiked = async (userId: string, trackId: string): Promise<bool
 
 // Define a TypeScript interface for a playlist
 interface PlaylistData {
-  name: string; // Playlist name
+  title: string; // Playlist title
   description?: string; // Optional description
   ownerId: string; // User ID of the playlist owner
   imageUrl?: string; // Optional cover image URL
@@ -59,13 +59,13 @@ interface SavePlaylistParams {
 
 // Save a new playlist created by the user
 export const savePlaylist = async ({ userId, playlistData }: SavePlaylistParams) => {
-  if (!userId || !playlistData.name) {
+  if (!userId || !playlistData.title) {
     console.error('Missing userId or playlist name');
     return;
   }
 
   const playlistsColRef = collection(db, `users/${userId}/playlists`);
-  const playlistId = playlistData.name.replace(/\s+/g, '-').toLowerCase(); // Generate a unique ID based on the name
+  const playlistId = playlistData.title.replace(/\s+/g, '-').toLowerCase(); // Generate a unique ID based on the title
 
   const playlistRef = doc(playlistsColRef, playlistId);
 


### PR DESCRIPTION
## Summary
- refactor playlist creation to use `title`
- fetch playlists from the user's subcollection
- show cover art reliably in AlbumCard
- standardize playlist mapping in `useLibrary`
- add route handling for playlist items

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68433a103dc083248ee2b3597a0610b1