### PR TITLE
Improve player state persistence

### DIFF
--- a/src/features/player/AudioProvider.tsx
+++ b/src/features/player/AudioProvider.tsx
@@ -11,6 +11,7 @@ export function AudioProvider() {
     isPlaying,
     volume,
     isMuted,
+    currentTime,
     setCurrentTime,
     setDuration,
     setProgress,
@@ -24,6 +25,9 @@ export function AudioProvider() {
 
     audio.src = currentTrack.audioURL;
     audio.load();
+    if (currentTime > 0) {
+      audio.currentTime = currentTime;
+    }
 
     if (isPlaying) {
       audio.play().catch((err) => console.warn('Playback error:', err));


### PR DESCRIPTION
## Summary
- persist player store state across pages and reloads
- resume audio playback when the page is reloaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843399fb854832499d63c7fd2f9c040