### PR TITLE
Fix player overlay behaviour

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -21,7 +21,7 @@ This file is auto-generated.
 
 ---
 ### `src/features/player/MiniPlayer.tsx`
-- [77:12] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
+- [78:12] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 
 ---
 ### `src/features/player/QueueModal.tsx`

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -3,12 +3,10 @@
 import React, { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthProvider';
-import { usePlayerStore } from '@/features/player/store';
 
 import { SonixLogo } from '@/components/icons/SonixLogo';
 import BottomNavigationBar from '@/components/layout/BottomNavigationBar';
-import FullScreenPlayer from '@/features/player/FullScreenPlayer';
-import MiniPlayer from '@/features/player/MiniPlayer';
+import PlayerManager from '@/features/player/PlayerManager';
 import { AudioProvider } from '@/features/player/AudioProvider';
 import ProfileMenu from '@/components/layout/ProfileMenu';
 
@@ -17,8 +15,6 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const router = useRouter();
 
   const { user, loading, logout } = useAuth();
-  const currentTrack = usePlayerStore((s) => s.currentTrack);
-  const isExpanded = usePlayerStore((s) => s.isExpanded);
 
   useEffect(() => {
     if (!loading && !user && pathname !== '/login') {
@@ -67,8 +63,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
           : children}
       </main>
 
-      {currentTrack && !isExpanded && <MiniPlayer />}
-      {currentTrack && isExpanded && <FullScreenPlayer />}
+      <PlayerManager />
       {showLayout && <BottomNavigationBar />}
       <AudioProvider />
     </div>

--- a/src/features/player/MiniPlayer.tsx
+++ b/src/features/player/MiniPlayer.tsx
@@ -29,7 +29,8 @@ export default function MiniPlayer() {
   return (
     <button
       type="button"
-      className="animate-slideInUpMini fixed inset-x-0 bottom-16 z-50 flex h-20 items-center border-t border-border/70 bg-card/80 px-4 shadow-2xl backdrop-blur-lg transition-transform duration-300 ease-in-out md:bottom-0 md:px-6"
+      className="animate-slideInUpMini fixed inset-x-0 z-50 flex h-20 items-center border-t border-border/70 bg-card/80 px-4 shadow-2xl backdrop-blur-lg transition-transform duration-300 ease-in-out md:bottom-4 md:px-6"
+      style={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
       aria-label="Mini Music Player"
       onClick={() => toggleExpand()}
     >

--- a/src/features/player/PlayerManager.tsx
+++ b/src/features/player/PlayerManager.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePlayerStore } from './store';
+import MiniPlayer from './MiniPlayer';
+import FullScreenPlayer from './FullScreenPlayer';
+
+export default function PlayerManager() {
+  const isExpanded = usePlayerStore((s) => s.isExpanded);
+  const currentTrack = usePlayerStore((s) => s.currentTrack);
+
+  useEffect(() => {
+    if (isExpanded) {
+      const originalOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = originalOverflow;
+      };
+    }
+  }, [isExpanded]);
+
+  if (!currentTrack) return null;
+
+  return isExpanded ? <FullScreenPlayer /> : <MiniPlayer />;
+}


### PR DESCRIPTION
## Summary
- manage players globally with new `PlayerManager`
- apply `PlayerManager` in `ClientLayout`
- keep body scrolling locked while fullscreen player is open
- adjust MiniPlayer bottom spacing so it stays above footers
- update lint tracking file

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68448a10d7d0832481c01d1c0e74c004