### PR TITLE
Fix mini and full player layout

### DIFF
--- a/src/features/player/FullScreenPlayer.tsx
+++ b/src/features/player/FullScreenPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { usePlayerStore } from './store';
@@ -9,8 +9,10 @@ import { formatTime } from '@/lib/utils';
 import { Slider } from '@/components/ui/slider';
 import { Button } from '@/components/ui/button';
 import { ChevronDown, ListMusic, Shuffle, Repeat, Repeat1, VolumeX, Volume2, Play, Pause, SkipForward, SkipBack } from 'lucide-react';
+import QueueModal from './QueueModal';
 
 export default function FullScreenPlayer() {
+  const [showQueue, setShowQueue] = useState(false);
   const {
     currentTrack,
     isPlaying,
@@ -85,6 +87,7 @@ export default function FullScreenPlayer() {
           variant="ghost"
           size="icon"
           className="z-[110] text-muted-foreground transition-colors hover:text-accent"
+          onClick={() => setShowQueue(true)}
           aria-label="View Queue"
         >
           <ListMusic size={22} />
@@ -197,6 +200,8 @@ export default function FullScreenPlayer() {
           {getRepeatIcon()}
         </Button>
       </div>
+
+      <QueueModal isOpen={showQueue} onClose={() => setShowQueue(false)} />
     </div>
   );
 }

--- a/src/features/player/MiniPlayer.tsx
+++ b/src/features/player/MiniPlayer.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import { usePlayerStore } from './store';
-import { formatArtists } from '@/utils/formatArtists';
 import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { Play, Pause } from 'lucide-react';
 import { Progress } from '@/components/ui/progress';
@@ -30,41 +29,33 @@ export default function MiniPlayer() {
     <button
       type="button"
       className="animate-slideInUpMini fixed inset-x-0 z-50 flex h-20 items-center border-t border-border/70 bg-card/80 px-4 shadow-2xl backdrop-blur-lg transition-transform duration-300 ease-in-out md:bottom-4 md:px-6"
-      style={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
+      style={{ bottom: `calc(4rem + env(safe-area-inset-bottom))` }}
       aria-label="Mini Music Player"
       onClick={() => toggleExpand()}
     >
-      {/* Expand FullScreenPlayer */}
-      <div className="group flex min-w-0 flex-1 items-center gap-3 md:gap-4">
-        {/* Cover Image */}
-        <div
-          className={`relative size-12 overflow-hidden rounded-md shadow-md transition-shadow group-hover:shadow-primary/30 md:size-14 ${
-            isPlaying ? 'animate-pulse' : ''
-          }`}
-        >
-          <Image
-            src={currentTrack.coverURL || DEFAULT_COVER_URL}
-            alt={currentTrack.title || 'Unknown Track'}
-            fill
-            className="object-cover"
-            unoptimized
-          />
-        </div>
-
-        {/* Track Info */}
-        <div className="flex min-w-0 flex-col">
-          <p className="truncate text-sm font-semibold text-foreground transition-colors group-hover:text-primary md:text-base">
-            {currentTrack.title || 'Unknown Title'}
-          </p>
-          <p className="truncate text-xs text-muted-foreground md:text-sm">
-            {formatArtists(currentTrack.artists)}
-          </p>
-        </div>
+      {/* Cover Image */}
+      <div
+        className={`relative mr-3 size-12 overflow-hidden rounded-md shadow-md transition-shadow group-hover:shadow-primary/30 md:mr-4 md:size-14 ${
+          isPlaying ? 'animate-pulse' : ''
+        }`}
+      >
+        <Image
+          src={currentTrack.coverURL || DEFAULT_COVER_URL}
+          alt={currentTrack.title || 'Unknown Track'}
+          fill
+          className="object-cover"
+          unoptimized
+        />
       </div>
 
-      {/* Play/Pause Button */}
+      {/* Track Title */}
+      <p className="flex-1 truncate text-left text-sm font-semibold text-foreground md:text-base">
+        {currentTrack.title || 'Unknown Title'}
+      </p>
+
+      {/* Play/Pause */}
       <button
-        className="ml-auto flex items-center justify-center rounded-full bg-primary p-2 text-white shadow-md hover:bg-primary/90"
+        className="ml-3 flex items-center justify-center rounded-full bg-primary p-2 text-white shadow-md hover:bg-primary/90"
         onClick={(e) => {
           e.stopPropagation();
           togglePlayPause();
@@ -75,7 +66,7 @@ export default function MiniPlayer() {
       </button>
 
       {/* Progress Bar */}
-      <div className="absolute bottom-0 inset-x-0 h-1 bg-secondary/30">
+      <div className="absolute inset-x-0 bottom-0 h-1 bg-secondary/30">
         <Progress
           value={progress}
           className="h-full [&>div]:bg-gradient-to-r [&>div]:from-accent/70 [&>div]:to-primary/70"


### PR DESCRIPTION
## Summary
- refresh MiniPlayer UI and flush it to bottom nav bar
- allow fullscreen player to open queue modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448df4f77083249079b6223b7d1526