### PR TITLE
Improve queue handling and playback restart

### DIFF
--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -42,6 +42,7 @@ export default function AlbumPage() {
   const setCurrentTrack = usePlayerStore((s) => s.setCurrentTrack);
   const setIsPlaying = usePlayerStore((s) => s.setIsPlaying);
   const setQueue = usePlayerStore((s) => s.setQueue);
+  const addTracksToQueue = usePlayerStore((s) => s.addTracksToQueue);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -87,7 +88,7 @@ export default function AlbumPage() {
   };
 
   const handleAddAlbumToQueue = () => {
-    setQueue([...tracks]);
+    addTracksToQueue(tracks);
     toast({ title: 'Added album to queue' });
   };
 

--- a/src/app/single/[singleId]/page.tsx
+++ b/src/app/single/[singleId]/page.tsx
@@ -52,6 +52,7 @@ export default function SingleDetailPage() {
   const setCurrentTrack = usePlayerStore((s) => s.setCurrentTrack);
   const setIsPlaying = usePlayerStore((s) => s.setIsPlaying);
   const setQueue = usePlayerStore((s) => s.setQueue);
+  const addTracksToQueue = usePlayerStore((s) => s.addTracksToQueue);
   const { toast } = useToast();
   const [single, setSingle] = useState<Single | null>(null);
   const [artistsDetails, setArtistsDetails] = useState<Artist[]>([]);
@@ -238,7 +239,7 @@ export default function SingleDetailPage() {
               <Button
                 size="sm"
                 onClick={() => {
-                  setQueue(single.tracklist);
+                  addTracksToQueue(single.tracklist);
                   toast({ title: 'Added to queue' });
                 }}
               >

--- a/src/components/music/TrackActions.tsx
+++ b/src/components/music/TrackActions.tsx
@@ -17,8 +17,7 @@ interface Props {
 }
 
 export default function TrackActions({ track }: Props) {
-  const queue = usePlayerStore((s) => s.queue);
-  const setQueue = usePlayerStore((s) => s.setQueue);
+  const addToQueue = usePlayerStore((s) => s.addToQueue);
   const router = useRouter();
 
   const handleFavorite = () => {
@@ -27,8 +26,7 @@ export default function TrackActions({ track }: Props) {
 
   
   const handleAddToQueue = () => {
-    // Add the track to the queue
-    setQueue([...queue, track]);
+    addToQueue(track);
   };
 
   return (

--- a/src/features/player/AudioProvider.tsx
+++ b/src/features/player/AudioProvider.tsx
@@ -18,23 +18,21 @@ export function AudioProvider() {
     skipToNext,
   } = usePlayerStore();
 
-  // Handle track change or play/pause toggle
+  // Handle track change, play/pause toggle and seeking
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio || !currentTrack) return;
 
     audio.src = currentTrack.audioURL;
     audio.load();
-    if (currentTime > 0) {
-      audio.currentTime = currentTime;
-    }
+    audio.currentTime = currentTime;
 
     if (isPlaying) {
       audio.play().catch((err) => console.warn('Playback error:', err));
     } else {
       audio.pause();
     }
-  }, [currentTrack, isPlaying]);
+  }, [currentTrack, isPlaying, currentTime]);
 
   // Sync volume and mute
   useEffect(() => {

--- a/src/features/player/store.ts
+++ b/src/features/player/store.ts
@@ -24,6 +24,7 @@ type PlayerStore = {
   setCurrentTrack: (track: Track | null) => void;
   setIsPlaying: (val: boolean) => void;
   addToQueue: (track: Track) => void;
+  addTracksToQueue: (tracks: Track[]) => void;
   togglePlayPause: () => void;
   toggleExpand: () => void;
   setProgress: (val: number) => void;
@@ -62,6 +63,9 @@ export const usePlayerStore = create<PlayerStore>()(
           queueIndex: index >= 0 ? index : 0,
           isPlaying: true,
           isExpanded: false,
+          currentTime: 0,
+          progress: 0,
+          duration: 0,
         });
       },
 
@@ -69,10 +73,14 @@ export const usePlayerStore = create<PlayerStore>()(
         set({
           currentTrack: track,
           isExpanded: false,
+          currentTime: 0,
+          progress: 0,
+          duration: 0,
         }),
       setIsPlaying: (val) => set({ isPlaying: val }),
 
       addToQueue: (track) => set((s) => ({ queue: [...s.queue, track] })),
+      addTracksToQueue: (tracks) => set((s) => ({ queue: [...s.queue, ...tracks] })),
 
       setQueue: (tracks) => {
         set({
@@ -81,6 +89,9 @@ export const usePlayerStore = create<PlayerStore>()(
           currentTrack: tracks[0] ?? null,
           isPlaying: !!tracks[0],
           isExpanded: false,
+          currentTime: 0,
+          progress: 0,
+          duration: 0,
         });
       },
 


### PR DESCRIPTION
## Summary
- reset playback state when setting or queuing tracks
- support adding multiple tracks to queue
- keep playing current song when adding to queue
- ensure audio element seeks to currentTime on updates

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68449b284ef083248d705be08cf85fbb