### PR TITLE
Fix player queue view and stuttering playback

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -16,11 +16,3 @@ This file is auto-generated.
 - [27:23] Classname 'destructive' is not a Tailwind CSS class! – `tailwindcss/no-custom-classname`
 
 ---
-### `src/features/player/AudioProvider.tsx`
-- [37:6] React Hook useEffect has a missing dependency: 'currentTime'. Either include it or remove the dependency array. – `react-hooks/exhaustive-deps`
-
----
-### `src/features/player/FullScreenPlayer.tsx`
-- [92:9] 'handleAddToQueue' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-
----

--- a/src/features/player/AudioProvider.tsx
+++ b/src/features/player/AudioProvider.tsx
@@ -18,21 +18,36 @@ export function AudioProvider() {
     skipToNext,
   } = usePlayerStore();
 
-  // Handle track change, play/pause toggle and seeking
+  // Load new track
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio || !currentTrack) return;
 
     audio.src = currentTrack.audioURL;
     audio.load();
-    audio.currentTime = currentTime;
+  }, [currentTrack]);
+
+  // Play / pause
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
 
     if (isPlaying) {
       audio.play().catch((err) => console.warn('Playback error:', err));
     } else {
       audio.pause();
     }
-  }, [currentTrack, isPlaying, currentTime]);
+  }, [isPlaying]);
+
+  // Seek to currentTime changes
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (Math.abs(audio.currentTime - currentTime) > 0.1) {
+      audio.currentTime = currentTime;
+    }
+  }, [currentTime]);
 
   // Sync volume and mute
   useEffect(() => {

--- a/src/features/player/FullScreenPlayer.tsx
+++ b/src/features/player/FullScreenPlayer.tsx
@@ -23,7 +23,6 @@ import {
 } from 'lucide-react';
 
 // Import or define the Track type
-import { Track } from '@/types/music'; // Replace with the correct path if needed
 
 export default function FullScreenPlayer() {
   const [showQueue, setShowQueue] = useState(false); // State to toggle queue modal
@@ -45,7 +44,6 @@ export default function FullScreenPlayer() {
     toggleRepeat,
     queue,
     queueIndex,
-    setQueue,
     setCurrentTrack,
   } = usePlayerStore();
 
@@ -87,10 +85,6 @@ export default function FullScreenPlayer() {
     } else {
       console.warn('No previous track in the queue.');
     }
-  };
-
-  const handleAddToQueue = (track: Track) => {
-    setQueue([...queue, track]);
   };
 
   return (
@@ -160,12 +154,7 @@ export default function FullScreenPlayer() {
         >
           <Shuffle size={20} />
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={handleSkipToPrev}
-          aria-label="Previous Track"
-        >
+        <Button variant="ghost" size="icon" onClick={handleSkipToPrev} aria-label="Previous Track">
           <SkipBack size={24} />
         </Button>
         <Button
@@ -176,20 +165,10 @@ export default function FullScreenPlayer() {
         >
           {isPlaying ? <Pause size={32} /> : <Play size={32} />}
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={handleSkipToNext}
-          aria-label="Next Track"
-        >
+        <Button variant="ghost" size="icon" onClick={handleSkipToNext} aria-label="Next Track">
           <SkipForward size={24} />
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={toggleRepeat}
-          aria-label="Repeat"
-        >
+        <Button variant="ghost" size="icon" onClick={toggleRepeat} aria-label="Repeat">
           {getRepeatIcon()}
         </Button>
       </div>
@@ -215,12 +194,7 @@ export default function FullScreenPlayer() {
       </div>
 
       {/* Queue Modal */}
-      {showQueue && (
-        <QueueModal
-          isOpen={showQueue}
-          onClose={() => setShowQueue(false)}
-        />
-      )}
+      {showQueue && <QueueModal isOpen={showQueue} onClose={() => setShowQueue(false)} />}
     </div>
   );
 }

--- a/src/features/player/QueueModal.tsx
+++ b/src/features/player/QueueModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePlayerStore } from './store';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import Image from 'next/image';
 import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { formatArtists } from '@/utils/formatArtists';
@@ -31,11 +31,14 @@ export default function QueueModal({ isOpen, onClose }: QueueModalProps) {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="fixed inset-x-0 bottom-0 max-h-[80vh] overflow-y-auto rounded-t-lg bg-card p-4 shadow-lg">
-        <DialogHeader>
-          <DialogTitle className="text-lg font-bold">Up Next</DialogTitle>
-        </DialogHeader>
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent
+        side="bottom"
+        className="max-h-[80vh] overflow-y-auto rounded-t-lg bg-card p-4 shadow-lg"
+      >
+        <SheetHeader>
+          <SheetTitle className="text-lg font-bold">Up Next</SheetTitle>
+        </SheetHeader>
         <div className="flex flex-col gap-2">
           {queue.map((track, index) => (
             <button
@@ -86,7 +89,7 @@ export default function QueueModal({ isOpen, onClose }: QueueModalProps) {
             </button>
           ))}
         </div>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Summary
- improve `AudioProvider` to avoid reloading audio on each time update
- remove unused code from `FullScreenPlayer`
- show queue using a bottom sheet instead of dialog
- update FIXME after lint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format:check` *(fails: Code style issues found in 22 files)*

------
https://chatgpt.com/codex/tasks/task_e_68449e91687c83249213f017ed51b40d