### PR TITLE
Add artist follow and realtime profile

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,10 +21,17 @@ service cloud.firestore {
     match /artists/{artistId} {
       allow read: if true;
       allow write: if request.auth != null && isAdmin();
+      match /followers/{userId} {
+        allow read: if true;
+        allow write: if request.auth != null && request.auth.uid == userId;
+      }
     }
     match /profiles/{userId} {
       allow read: if resource.data.isProfilePublic == true || request.auth != null && request.auth.uid == userId;
       allow write: if request.auth != null && request.auth.uid == userId;
+      match /followingArtists/{artistId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     // Allow users to manage playlists stored at the root

--- a/src/utils/followArtist.ts
+++ b/src/utils/followArtist.ts
@@ -1,0 +1,18 @@
+import { db } from '@/lib/firebase';
+import { doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+
+export async function followArtist(userId: string, artistId: string) {
+  if (!userId || !artistId) return;
+  const followerRef = doc(db, 'artists', artistId, 'followers', userId);
+  const followingRef = doc(db, 'profiles', userId, 'followingArtists', artistId);
+  await setDoc(followerRef, { createdAt: serverTimestamp() });
+  await setDoc(followingRef, { createdAt: serverTimestamp() });
+}
+
+export async function unfollowArtist(userId: string, artistId: string) {
+  if (!userId || !artistId) return;
+  const followerRef = doc(db, 'artists', artistId, 'followers', userId);
+  const followingRef = doc(db, 'profiles', userId, 'followingArtists', artistId);
+  await deleteDoc(followerRef).catch(() => {});
+  await deleteDoc(followingRef).catch(() => {});
+}


### PR DESCRIPTION
## Summary
- add follow/unfollow helpers for artists
- support followers subcollection in Firestore rules
- update artist page with follow button and real‑time updates
- make profile page update in real‑time

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449f9a90f8832493b2ed279dce596e