### PR TITLE
Fix album track management

### DIFF
--- a/src/app/artist/[artistId]/page.tsx
+++ b/src/app/artist/[artistId]/page.tsx
@@ -39,13 +39,16 @@ export default function ArtistPage() {
       if (!snap.empty) setArtistProfile(snap.docs[0].data());
     });
 
-    const albumQuery = query(collection(db, 'albums'), where('artist', '==', decodedId));
+    const albumQuery = query(
+      collection(db, 'albums'),
+      where('artistIds', 'array-contains', decodedId)
+    );
     const unsubAlbums = onSnapshot(albumQuery, (snap) => {
       setAlbums(
         snap.docs.map((doc) => ({
           id: doc.id,
           title: doc.data().title || 'Untitled',
-          artists: doc.data().artists || [{ id: '', name: doc.data().artist || decodedId }],
+          artists: doc.data().artists || [{ id: '', name: 'Unknown Artist' }],
           genre: doc.data().genre || '',
           type: 'album' as const,
           audioURL: '',
@@ -54,7 +57,10 @@ export default function ArtistPage() {
       );
     });
 
-    const singleQuery = query(collection(db, 'tracks'), where('artist', '==', decodedId));
+    const singleQuery = query(
+      collection(db, 'songs'),
+      where('artistIds', 'array-contains', decodedId)
+    );
     const unsubSingles = onSnapshot(singleQuery, (snap) => {
       setSingles(
         snap.docs.map((doc) => ({
@@ -69,7 +75,7 @@ export default function ArtistPage() {
       );
     });
 
-    const featuredQuery = query(collection(db, 'tracks'), where('artists', 'array-contains', decodedId));
+    const featuredQuery = query(collection(db, 'songs'), where('artistIds', 'array-contains', decodedId));
     const unsubFeatured = onSnapshot(featuredQuery, (snap) => {
       const filtered = snap.docs
         .map((doc) => {
@@ -77,7 +83,7 @@ export default function ArtistPage() {
           return {
             id: doc.id,
             title: data.title || 'Untitled',
-            artists: data.artists || [{ id: '', name: data.artist || '' }],
+            artists: data.artists || [{ id: '', name: 'Unknown Artist' }],
             genre: data.genre || '',
             type: 'track' as const,
             audioURL: data.audioURL || data.audioSrc || '',

--- a/src/app/genre/[genre]/page.tsx
+++ b/src/app/genre/[genre]/page.tsx
@@ -22,7 +22,7 @@ export default function GenrePage() {
 
   useEffect(() => {
     const fetchGenreTracks = async () => {
-      const q = query(collection(db, 'tracks'), where('genre', '==', genre));
+      const q = query(collection(db, 'songs'), where('genre', '==', genre));
       const snap = await getDocs(q);
       setTracks(snap.docs.map((doc) => doc.data() as Track));
     };

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -42,7 +42,9 @@ export default function SearchPage() {
       const results = await searchLibrary(searchTerm);
 
       setSearchResults({
-        songs: results.songs.map((song: Song) => normalizeTrack(song)),
+        songs: results.songs.map((song: Song) =>
+          normalizeTrack(song, (song as any).artists || [])
+        ),
         albums: results.albums,
         artists: results.artists,
         users: results.users,

--- a/src/components/music/TrackActions.tsx
+++ b/src/components/music/TrackActions.tsx
@@ -11,6 +11,10 @@ import { usePlayerStore } from '@/features/player/store';
 import { useRouter } from 'next/navigation';
 import type { Track } from '@/types/music';
 import AddToPlaylistModal from '@/components/playlists/AddToPlaylistModal';
+import { getAuth } from 'firebase/auth';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import { useToast } from '@/hooks/use-toast';
 
 interface Props {
   track: Track;
@@ -19,6 +23,7 @@ interface Props {
 export default function TrackActions({ track }: Props) {
   const addToQueue = usePlayerStore((s) => s.addToQueue);
   const router = useRouter();
+  const { toast } = useToast();
 
   const handleFavorite = () => {
     // TODO: implement favorite functionality
@@ -27,6 +32,16 @@ export default function TrackActions({ track }: Props) {
   
   const handleAddToQueue = () => {
     addToQueue(track);
+  };
+
+  const handleAddToLibrary = async () => {
+    const user = getAuth().currentUser;
+    if (!user) return;
+    await setDoc(doc(db, 'profiles', user.uid, 'likedSongs', track.id), {
+      id: track.id,
+      addedAt: serverTimestamp(),
+    });
+    toast({ title: 'Saved to library' });
   };
 
   return (
@@ -57,6 +72,10 @@ export default function TrackActions({ track }: Props) {
         <DropdownMenuItem onClick={handleAddToQueue}>
           <Plus className="mr-2 size-4" />
           Add to Queue
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleAddToLibrary}>
+          <Heart className="mr-2 size-4" />
+          Add to Library
         </DropdownMenuItem>
         {track.artists && typeof track.artists === 'string' && (
           <DropdownMenuItem onClick={() => router.push(`/artist/${track.artists}`)}>


### PR DESCRIPTION
## Summary
- fix search track normalization to include artists
- query songs instead of tracks across album, artist and genre pages
- refactor album detail page to support album play
- support saving individual tracks to library

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68460e9d21e88324becee8af5fb177f7