### PR TITLE
Fix album uploads appearing as singles

### DIFF
--- a/src/app/artist/[artistId]/page.tsx
+++ b/src/app/artist/[artistId]/page.tsx
@@ -59,7 +59,8 @@ export default function ArtistPage() {
 
     const singleQuery = query(
       collection(db, 'songs'),
-      where('artistIds', 'array-contains', decodedId)
+      where('artistIds', 'array-contains', decodedId),
+      where('type', '==', 'single')
     );
     const unsubSingles = onSnapshot(singleQuery, (snap) => {
       setSingles(

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -17,18 +17,20 @@ export default function DiscoverPage() {
       const q = query(tracksRef, orderBy('createdAt', 'desc'), limit(20));
       const snapshot = await getDocs(q);
 
-      const fetchedTracks: Track[] = snapshot.docs.map((doc) => {
-        const data = doc.data();
-        return {
-          id: doc.id,
-          title: data.title,
-          artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
-          audioURL: data.audioURL,
-          coverURL: data.coverURL,
-          duration: data.duration,
-          type: 'track',
-        };
-      });
+      const fetchedTracks: Track[] = snapshot.docs
+        .map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            title: data.title,
+            artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
+            audioURL: data.audioURL,
+            coverURL: data.coverURL,
+            duration: data.duration,
+            type: data.type || 'track',
+          };
+        })
+        .filter((t) => t.type !== 'album');
 
       setTracks(fetchedTracks);
     }

--- a/src/app/genre/[genre]/page.tsx
+++ b/src/app/genre/[genre]/page.tsx
@@ -24,7 +24,11 @@ export default function GenrePage() {
     const fetchGenreTracks = async () => {
       const q = query(collection(db, 'songs'), where('genre', '==', genre));
       const snap = await getDocs(q);
-      setTracks(snap.docs.map((doc) => doc.data() as Track));
+      setTracks(
+        snap.docs
+          .map((doc) => ({ ...(doc.data() as Track), id: doc.id }))
+          .filter((t) => (t as any).type !== 'album')
+      );
     };
     fetchGenreTracks();
   }, [genre]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,19 +21,21 @@ export default function Home() {
         const q = query(songsRef, orderBy('createdAt', 'desc'));
         const snapshot = await getDocs(q);
 
-        const tracks: Track[] = snapshot.docs.map((doc) => {
-          const data = doc.data();
+        const tracks: Track[] = snapshot.docs
+          .map((doc) => {
+            const data = doc.data();
 
-          return {
-            id: doc.id,
-            title: data.title,
-            artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
-            audioURL: data.audioURL,
-            coverURL: data.coverURL,
-            duration: data.duration || 0,
-            type: 'track',
-          };
-        });
+            return {
+              id: doc.id,
+              title: data.title,
+              artists: data.artists || [{ id: '', name: data.artist || 'Unknown Artist' }],
+              audioURL: data.audioURL,
+              coverURL: data.coverURL,
+              duration: data.duration || 0,
+              type: data.type || 'track',
+            };
+          })
+          .filter((t) => t.type !== 'album');
 
         setRecentSongs(tracks.slice(0, 10));
         setTrendingSongs(tracks.slice(0, 5));

--- a/src/utils/searchLibrary.ts
+++ b/src/utils/searchLibrary.ts
@@ -36,7 +36,9 @@ export async function searchLibrary(term: string): Promise<SearchResults> {
       getDocs(query(collection(db, 'profiles'), where('isProfilePublic', '==', true))),
     ]);
 
-    const songs = songsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Song[];
+    const songs = songsSnap.docs
+      .map((d) => ({ id: d.id, ...d.data() }))
+      .filter((s: any) => s.type === 'single' || !s.type) as Song[];
     const albums = albumsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Album[];
     const artists = artistsSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Artist[];
     const users = usersSnap.docs


### PR DESCRIPTION
## Summary
- filter singles on artist pages to ignore album tracks
- exclude album songs from home, discover and genre lists
- refine search to only include singles

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_6846131c509c8324b374c5566a73dd49