### PR TITLE
Fix artist display in search results

### DIFF
--- a/src/utils/normalizeTrack.ts
+++ b/src/utils/normalizeTrack.ts
@@ -12,10 +12,26 @@ export function normalizeTrack(
     (data.artistIds || []).includes(artist.id)
   );
 
+  // Fallback to artists stored on the document when artistIds are missing
+  let artists = matchingArtists;
+  if (artists.length === 0) {
+    if (Array.isArray(data.artists) && data.artists.length > 0) {
+      artists = data.artists.map((a: any) =>
+        typeof a === 'object' ? { id: a.id || '', name: a.name || '' } : { id: '', name: a }
+      );
+    } else if (data.artist) {
+      artists = [
+        typeof data.artist === 'object'
+          ? { id: data.artist.id || '', name: data.artist.name || '' }
+          : { id: '', name: data.artist },
+      ];
+    }
+  }
+
   return {
-    id: doc.id || '',
+    id: data.id || doc.id || '',
     title: data.title || 'Untitled',
-    artists: matchingArtists.length > 0 ? matchingArtists : [{ id: '', name: 'Unknown Artist' }],
+    artists: artists.length > 0 ? artists : [{ id: '', name: 'Unknown Artist' }],
 
     audioURL: data.audioURL || '',
     coverURL: data.coverURL || DEFAULT_COVER_URL,

--- a/src/utils/searchLibrary.ts
+++ b/src/utils/searchLibrary.ts
@@ -43,6 +43,23 @@ export async function searchLibrary(term: string): Promise<SearchResults> {
       .map((d) => ({ id: d.id, ...d.data() }))
       .filter((u: any) => u.isProfilePublic !== false) as UserResult[];
 
+    const artistMap = new Map(artists.map((a) => [a.id, a.name]));
+
+    const attachArtists = (ids: string[] | undefined) =>
+      (ids || []).map((id) => ({ id, name: artistMap.get(id) || 'Unknown Artist' }));
+
+    songs.forEach((s: any) => {
+      if (!s.artists || s.artists.length === 0) {
+        s.artists = attachArtists(s.artistIds);
+      }
+    });
+
+    albums.forEach((a: any) => {
+      if (!a.artists || a.artists.length === 0) {
+        a.artists = attachArtists(a.artistIds);
+      }
+    });
+
     const filteredSongs = songs.filter((s) => {
       const title = (s as any).title || '';
       const artist =
@@ -65,9 +82,7 @@ export async function searchLibrary(term: string): Promise<SearchResults> {
     });
 
     const filteredArtists = artists.filter((a) => (a.name || '').toLowerCase().includes(search));
-    const filteredUsers = users.filter((u) =>
-      (u.displayName || '').toLowerCase().includes(search),
-    );
+    const filteredUsers = users.filter((u) => (u.displayName || '').toLowerCase().includes(search));
     return {
       songs: filteredSongs,
       albums: filteredAlbums,


### PR DESCRIPTION
## Summary
- ensure `normalizeTrack` falls back to embedded artist data
- attach artist details to songs and albums in `searchLibrary`

## Testing
- `npx prettier -w src/utils/normalizeTrack.ts src/utils/searchLibrary.ts`
- `npx eslint src/utils/normalizeTrack.ts src/utils/searchLibrary.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461569b9ac83248e8803b274c0f1bd