### PR TITLE
Group album songs under album collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,6 +17,10 @@ service cloud.firestore {
     match /albums/{albumId} {
       allow read: if true;
       allow write: if request.auth != null && isAdmin();
+      match /songs/{songId} {
+        allow read: if true;
+        allow write: if request.auth != null && isAdmin();
+      }
     }
     match /artists/{artistId} {
       allow read: if true;

--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -170,7 +170,10 @@ export default function AdminUploadPage() {
           });
         });
 
-        const newDocRef = doc(collection(db, 'songs'));
+        const newDocRef =
+          type === 'album'
+            ? doc(collection(db, 'albums', albumId, 'songs'))
+            : doc(collection(db, 'songs'));
 
         const songMainNames = song.mainArtists ? parseNames(song.mainArtists) : albumMainNames;
         const songFeaturedNames = song.featuredArtists

--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -74,8 +74,9 @@ export default function AlbumPage() {
             }));
           }
 
-          const trackQuery = query(collection(db, 'songs'), where('albumId', '==', String(albumId)));
-          const trackSnap = await getDocs(trackQuery);
+          const trackSnap = await getDocs(
+            collection(db, 'albums', String(albumId), 'songs'),
+          );
 
           const fetchedTracks: Track[] = trackSnap.docs
             .map((doc) => normalizeTrack(doc, fetchedArtists))


### PR DESCRIPTION
## Summary
- store uploaded album tracks inside `albums/{albumId}/songs`
- update rules to allow reading/writing nested album songs
- load tracks for album pages from new nested collection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684622883f308324a5f488f9efa49714