### PR TITLE
Fix album card artist info

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -7,8 +7,9 @@ This file is auto-generated.
 - [10:3] 'doc' is defined but never used. – `@typescript-eslint/no-unused-vars`
 - [11:3] 'getDoc' is defined but never used. – `@typescript-eslint/no-unused-vars`
 - [53:11] 'unsubAlbums' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-- [71:11] 'unsubSingles' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-- [86:11] 'unsubFeatured' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
+- [79:11] 'unsubSingles' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
+- [94:11] 'unsubFeatured' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
+- [133:6] React Hook useEffect has a missing dependency: 'artistProfile?.name'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setAlbums' needs the current value of 'artistProfile.name'. – `react-hooks/exhaustive-deps`
 
 ---
 ### `src/components/music/QueueModal.tsx`

--- a/src/app/artist/[artistId]/page.tsx
+++ b/src/app/artist/[artistId]/page.tsx
@@ -55,7 +55,15 @@ export default function ArtistPage() {
         snap.docs.map((doc) => ({
           id: doc.id,
           title: doc.data().title || 'Untitled',
-          artists: doc.data().artists || [{ id: '', name: 'Unknown Artist' }],
+          artists:
+            doc.data().artists && doc.data().artists.length > 0
+              ? doc.data().artists
+              : [
+                  {
+                    id: decodedId,
+                    name: artistProfile?.name || 'Unknown Artist',
+                  },
+                ],
           genre: doc.data().genre || '',
           type: 'album' as const,
           audioURL: '',

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -111,7 +111,12 @@ export default function SearchPage() {
                     id: album.id,
                     type: 'album',
                     title: (album as any).title || '',
-                    artists: (album as any).artist ? [{ id: '', name: (album as any).artist }] : [],
+                    artists:
+                      (album as any).artists && (album as any).artists.length > 0
+                        ? (album as any).artists
+                        : (album as any).artist
+                          ? [{ id: '', name: (album as any).artist }]
+                          : [],
                     audioURL: '',
                     coverURL: (album as any).coverURL || '',
                     album: (album as any).title || '',


### PR DESCRIPTION
## Summary
- ensure album cards display artist names on artist and search pages
- update FIXME log

## Testing
- `npm test`
- `npm run lint` *(fails: 5 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684622d4dde083248b1c88d2644f08c0