### PR TITLE
Handle singles in album cards

### DIFF
--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -18,7 +18,7 @@ import type { Track, Artist } from '@/types/music';
 import { useState, useEffect } from 'react';
 import { saveLikedSong, isSongLiked } from '@/utils/saveLibraryData';
 import { useUser } from '@/hooks/useUser';
-import { getTrackRoute, safeImageSrc } from '@/utils/helpers';
+import { getTrackRoute, safeImageSrc, formatArtists } from '@/utils/helpers';
 
 export function AlbumCard({ item, className }: { item: Track; className?: string }) {
   const router = useRouter();
@@ -28,7 +28,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
   const [isFavorited, setIsFavorited] = useState(false);
 
   // Determine type dynamically, falling back to album/single detection
-  const type = item.type || (item.albumId ? 'album' : 'single');
+  const type = item.type === 'album' || item.albumId ? 'album' : 'single';
   const id = item.id;
 
   // Generate the href dynamically based on type and id
@@ -73,15 +73,12 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
     }
   };
 
-  // Determine the artist display logic
-  const artistNames =
-    type === 'album'
-      ? item.artists.slice(0, 1).map((artist: Artist) => artist.name).join(', ') // Show only the main artist for albums
-      : item.artists
-          .map((artist: Artist, index: number) =>
-            index === 0 ? artist.name : `feat. ${artist.name}`
-          )
-          .join(', '); // Show main artist first, then featured artists for singles
+  // Determine the artist display logic with fallbacks for newly uploaded items
+  const artistNames = formatArtists(
+    item.artists?.length
+      ? item.artists
+      : (item as any).mainArtist || (item as any).artist || (item as any).artists
+  );
 
   return (
     <div
@@ -143,9 +140,7 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
       </div>
       <div className="p-3">
         <h3 className="truncate text-sm font-semibold">{item.title || (item as any).name}</h3>
-        {item.artists && (
-          <p className="truncate text-xs text-muted-foreground">{artistNames}</p>
-        )}
+        {artistNames && <p className="truncate text-xs text-muted-foreground">{artistNames}</p>}
       </div>
     </div>
   );

--- a/src/utils/normalizeTrack.ts
+++ b/src/utils/normalizeTrack.ts
@@ -24,22 +24,44 @@ export function normalizeTrack(
     } else if (data.artist) {
       artists = [
         typeof data.artist === 'object'
-          ? { id: data.artist.id || '', name: data.artist.name || '', coverURL: data.artist.coverURL || DEFAULT_COVER_URL }
+          ? {
+              id: data.artist.id || '',
+              name: data.artist.name || '',
+              coverURL: data.artist.coverURL || DEFAULT_COVER_URL,
+            }
           : { id: '', name: data.artist, coverURL: DEFAULT_COVER_URL },
       ];
+    } else if (data.mainArtist) {
+      const main =
+        typeof data.mainArtist === 'object'
+          ? {
+              id: data.mainArtist.id || '',
+              name: data.mainArtist.name || '',
+              coverURL: data.mainArtist.coverURL || DEFAULT_COVER_URL,
+            }
+          : { id: '', name: data.mainArtist, coverURL: DEFAULT_COVER_URL };
+      const featured = Array.isArray(data.featuredArtists)
+        ? data.featuredArtists.map((fa: any) =>
+            typeof fa === 'object'
+              ? { id: fa.id || '', name: fa.name || '', coverURL: fa.coverURL || DEFAULT_COVER_URL }
+              : { id: '', name: fa, coverURL: DEFAULT_COVER_URL }
+          )
+        : [];
+      artists = [main, ...featured];
     }
   }
 
   return {
     id: data.id || doc.id || '',
     title: data.title || 'Untitled',
-    artists: artists.length > 0
-      ? artists.map((a) => ({
-          coverURL: a.coverURL ?? DEFAULT_COVER_URL,
-          id: a.id,
-          name: a.name,
-        }))
-      : [{ id: '', name: 'Unknown Artist', coverURL: DEFAULT_COVER_URL }],
+    artists:
+      artists.length > 0
+        ? artists.map((a) => ({
+            coverURL: a.coverURL ?? DEFAULT_COVER_URL,
+            id: a.id,
+            name: a.name,
+          }))
+        : [{ id: '', name: 'Unknown Artist', coverURL: DEFAULT_COVER_URL }],
 
     audioURL: data.audioURL || '',
     coverURL: data.coverURL || DEFAULT_COVER_URL,


### PR DESCRIPTION
## Summary
- improve artist name formatting for album cards
- detect album vs single types more reliably
- allow `normalizeTrack` to parse main/featured artist fields

## Testing
- `bun run test` *(fails: No tests yet)*

------
https://chatgpt.com/codex/tasks/task_e_6847cef4b8e48324a82715b51aa0550f