### PR TITLE
Add admin dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Upload, BarChart2 } from 'lucide-react';
+
+import { useAuth } from '@/contexts/AuthProvider';
+import SectionTitle from '@/components/SectionTitle';
+import { Button } from '@/components/ui/button';
+
+export default function AdminDashboardPage() {
+  const { user, isAdmin, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && (!user || !isAdmin)) {
+      router.replace('/');
+    }
+  }, [user, isAdmin, loading, router]);
+
+  return (
+    <div className="container mx-auto max-w-xl space-y-6 py-8">
+      <SectionTitle className="text-3xl font-bold">Admin Dashboard</SectionTitle>
+      <div className="grid gap-4">
+        <Button asChild variant="outline" className="h-32 w-full text-xl">
+          <Link href="/admin/upload" className="flex h-full w-full flex-col items-center justify-center gap-2">
+            <Upload size={32} />
+            Upload Music
+          </Link>
+        </Button>
+        <Button asChild variant="outline" className="h-32 w-full text-xl">
+          <Link href="/admin/streams" className="flex h-full w-full flex-col items-center justify-center gap-2">
+            <BarChart2 size={32} />
+            Stream Tracker
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/ProfileMenu.tsx
+++ b/src/components/layout/ProfileMenu.tsx
@@ -17,7 +17,7 @@ import {
   UserCog,
   LogIn,
   User as UserIcon,
-  Upload,
+  LayoutDashboard,
 } from 'lucide-react';
 
 interface ProfileMenuProps {
@@ -70,9 +70,9 @@ export default function ProfileMenu({ isAuthenticated, onLogout, userId, role }:
             </DropdownMenuItem>
             {role === 'admin' && (
               <DropdownMenuItem asChild>
-                <Link href="/admin/upload" className="flex cursor-pointer items-center hover:bg-accent/10">
-                  <Upload className="mr-2 size-4 text-primary" />
-                  <span>Upload Music</span>
+                <Link href="/admin" className="flex cursor-pointer items-center hover:bg-accent/10">
+                  <LayoutDashboard className="mr-2 size-4 text-primary" />
+                  <span>Admin Dashboard</span>
                 </Link>
               </DropdownMenuItem>
             )}


### PR DESCRIPTION
## Summary
- add admin dashboard page so admins can access upload and stream reports
- link to the dashboard from the profile menu

## Testing
- `npx eslint src/app/admin/page.tsx src/components/layout/ProfileMenu.tsx`
- `npm run typecheck` *(fails: Property 'streams' does not exist on type 'Track')*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_6847d52849988324a5b59cf409426358