### PR TITLE
Improve admin upload UX

### DIFF
--- a/FIXME.md
+++ b/FIXME.md
@@ -3,13 +3,6 @@
 This file is auto-generated.
 
 ---
-### `src/app/admin/upload/page.tsx`
-- [11:3] 'query' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [12:3] 'where' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [13:3] 'getDocs' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [51:9] 'handleReorder' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
-
----
 ### `src/components/music/QueueModal.tsx`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
 - [26:15] Invalid Tailwind CSS classnames order – `tailwindcss/classnames-order`
@@ -21,13 +14,5 @@ This file is auto-generated.
 ---
 ### `src/components/ui/toast.tsx`
 - [27:23] Classname 'destructive' is not a Tailwind CSS class! – `tailwindcss/no-custom-classname`
-
----
-### `src/features/player/QueueModal.tsx`
-- [9:13] 'GripVertical' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [11:10] 'DragDropContext' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [11:27] 'Droppable' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [11:38] 'Draggable' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [150:19] 'updatedQueue' is defined but never used. – `@typescript-eslint/no-unused-vars`
 
 ---

--- a/FIXME.md
+++ b/FIXME.md
@@ -3,11 +3,9 @@
 This file is auto-generated.
 
 ---
-### `src/app/admin/upload/page.tsx`
-- [11:3] 'query' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [12:3] 'where' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [13:3] 'getDocs' is defined but never used. – `@typescript-eslint/no-unused-vars`
-- [51:9] 'handleReorder' is assigned a value but never used. – `@typescript-eslint/no-unused-vars`
+### `src/app/admin/page.tsx`
+- [27:38] Classnames 'h-full, w-full' could be replaced by the 'size-full' shorthand! – `tailwindcss/enforces-shorthand`
+- [33:39] Classnames 'h-full, w-full' could be replaced by the 'size-full' shorthand! – `tailwindcss/enforces-shorthand`
 
 ---
 ### `src/components/music/QueueModal.tsx`

--- a/src/app/admin/streams/page.tsx
+++ b/src/app/admin/streams/page.tsx
@@ -12,7 +12,7 @@ import type { Track } from '@/types/music';
 export default function StreamStatsPage() {
   const router = useRouter();
   const { user, isAdmin, loading } = useAuth();
-  const [topTracks, setTopTracks] = useState<Track[]>([]);
+  const [topTracks, setTopTracks] = useState<(Track & { streams: number })[]>([]);
 
   useEffect(() => {
     if (!loading && (!user || !isAdmin)) {

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { RadioGroup } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import type { Track, Artist } from '@/types/music';
+import type { Track } from '@/types/music';
 import { useState, useEffect } from 'react';
 import { saveLikedSong, isSongLiked } from '@/utils/saveLibraryData';
 import { useUser } from '@/hooks/useUser';

--- a/src/features/player/QueueModal.tsx
+++ b/src/features/player/QueueModal.tsx
@@ -6,9 +6,8 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import Image from 'next/image';
 import { DEFAULT_COVER_URL } from '@/utils/helpers';
 import { formatArtists } from '@/utils/formatArtists';
-import { X, GripVertical } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Track } from '@/types/music';
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 
 interface QueueModalProps {
   isOpen: boolean;
@@ -119,35 +118,34 @@ export default function QueueModal({ isOpen, onClose }: QueueModalProps) {
                 />
               </div>
 
-                        {/* Track Info */}
-                        <div className="flex min-w-0 flex-col">
-                          <p className="truncate text-sm font-semibold">{track.title || 'Untitled'}</p>
-                          <p className="truncate text-xs text-muted-foreground">
-                            {formatArtists(track.artists)}
-                          </p>
-                        </div>
+              {/* Track Info */}
+              <div className="flex min-w-0 flex-col">
+                <p className="truncate text-sm font-semibold">{track.title || 'Untitled'}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {formatArtists(track.artists)}
+                </p>
+              </div>
 
-                        {/* Remove Button */}
-                        {index !== queueIndex && (
-                          <button
-                            className="ml-auto text-muted-foreground hover:text-destructive"
-                            onClick={(e) => {
-                              e.stopPropagation(); // Prevent triggering the track click
-                              handleRemoveTrack(index);
-                            }}
-                            aria-label={`Remove ${track.title} from queue`}
-                          >
-                            <X size={16} />
-                          </button>
-                        )}
-                      </div>
-                    ))}
+              {/* Remove Button */}
+              {index !== queueIndex && (
+                <button
+                  className="ml-auto text-muted-foreground hover:text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation(); // Prevent triggering the track click
+                    handleRemoveTrack(index);
+                  }}
+                  aria-label={`Remove ${track.title} from queue`}
+                >
+                  <X size={16} />
+                </button>
+              )}
+            </div>
+          ))}
         </div>
       </SheetContent>
     </Sheet>
   );
 }
 function setQueue(updatedQueue: Track[]) {
-  throw new Error('Function not implemented.');
+  usePlayerStore.setState({ queue: updatedQueue });
 }
-

--- a/src/hooks/useLibrary.ts
+++ b/src/hooks/useLibrary.ts
@@ -38,9 +38,7 @@ export function useLibrary() {
     setLoading(true);
     try {
       const likedSongsSnap = await getDocs(collection(db, 'users', user.uid, 'likedSongs'));
-      const savedAlbumsSnap = await getDocs(
-        collection(db, 'users', user.uid, 'savedAlbums')
-      );
+      const savedAlbumsSnap = await getDocs(collection(db, 'users', user.uid, 'savedAlbums'));
       const playlistsSnap = await getDocs(collection(db, 'users', user.uid, 'playlists'));
 
       const transformToTrack = (doc: any): Track => {
@@ -52,6 +50,8 @@ export function useLibrary() {
           audioURL: data.audioURL || '',
           coverURL: data.coverURL || DEFAULT_COVER_URL,
           type: data.type || 'track',
+          order: data.order || 0,
+          createdAt: data.createdAt || new Date(),
           albumId: data.albumId || '',
           album:
             data.album ||

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,8 +2,7 @@
 import type { Track } from '@/types/music';
 
 // Default image used when a track or album is missing artwork
-export const DEFAULT_COVER_URL =
-  'https://placehold.co/500x500?text=No+Image';
+export const DEFAULT_COVER_URL = 'https://placehold.co/500x500?text=No+Image';
 
 export function formatArtists(input: any): string {
   if (Array.isArray(input)) {
@@ -37,6 +36,8 @@ export function normalizeTrack(raw: any): Track {
     audioURL: raw.audioURL || raw.audioUrl || '',
     coverURL: raw.coverURL || raw.coverUrl || '',
     duration: raw.duration || 0,
+    order: raw.order || 0,
+    createdAt: raw.createdAt || new Date(),
     type: raw.type || 'track',
     albumId: raw.albumId,
     album: raw.album || undefined,


### PR DESCRIPTION
## Summary
- refine admin upload page with labeled sections
- show selected audio file names
- add drag-and-drop with fallback buttons to reorder songs
- clean up queue modal helper, album card and library helpers
- fix type errors in helpers and streams page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6847d67e40548324a961e8bc3a96ba8a