### PR TITLE
Fix player state persisting across refresh

### DIFF
--- a/src/features/player/store.ts
+++ b/src/features/player/store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { Track } from '@/types/music';
 
 type RepeatMode = 'off' | 'one' | 'all';
@@ -39,9 +38,7 @@ type PlayerStore = {
   skipToPrev: () => void;
 };
 
-export const usePlayerStore = create<PlayerStore>()(
-  persist(
-    (set, get) => ({
+export const usePlayerStore = create<PlayerStore>()((set, get) => ({
       currentTrack: null,
       isPlaying: false,
       isExpanded: false,
@@ -142,21 +139,4 @@ export const usePlayerStore = create<PlayerStore>()(
           });
         }
       },
-    }),
-    {
-      name: 'player-store',
-      partialize: (state) => ({
-        currentTrack: state.currentTrack,
-        isPlaying: state.isPlaying,
-        currentTime: state.currentTime,
-        duration: state.duration,
-        volume: state.volume,
-        isMuted: state.isMuted,
-        repeatMode: state.repeatMode,
-        shuffleMode: state.shuffleMode,
-        queue: state.queue,
-        queueIndex: state.queueIndex,
-      }),
-    }
-  )
-);
+    }));


### PR DESCRIPTION
## Summary
- remove `persist` usage in the player store so queue and playback state reset on reload

## Testing
- `npm test`
- `npm run lint` *(fails: GripVertical and DragDropContext unused in QueueModal, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847dad0fd0c83248a6dac8f8475375f