### PR TITLE
Fix scroll lock after closing player

### DIFF
--- a/src/features/player/PlayerManager.tsx
+++ b/src/features/player/PlayerManager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { usePlayerStore } from './store';
 import MiniPlayer from './MiniPlayer';
 import FullScreenPlayer from './FullScreenPlayer';
@@ -9,14 +9,25 @@ export default function PlayerManager() {
   const isExpanded = usePlayerStore((s) => s.isExpanded);
   const currentTrack = usePlayerStore((s) => s.currentTrack);
 
+  const originalOverflow = useRef<string | null>(null);
+
   useEffect(() => {
     if (isExpanded) {
-      const originalOverflow = document.body.style.overflow;
+      if (originalOverflow.current === null) {
+        originalOverflow.current = document.body.style.overflow;
+      }
       document.body.style.overflow = 'hidden';
-      return () => {
-        document.body.style.overflow = originalOverflow;
-      };
+    } else if (originalOverflow.current !== null) {
+      document.body.style.overflow = originalOverflow.current;
+      originalOverflow.current = null;
     }
+
+    return () => {
+      if (originalOverflow.current !== null) {
+        document.body.style.overflow = originalOverflow.current;
+        originalOverflow.current = null;
+      }
+    };
   }, [isExpanded]);
 
   if (!currentTrack) return null;


### PR DESCRIPTION
## Summary
- track and restore document body overflow state in `PlayerManager`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68486a03c588832496c4806723b9f1e4