### PR TITLE
Show order numbers when uploading album tracks

### DIFF
--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -269,7 +269,9 @@ export default function AdminUploadPage() {
                         onDrop={() => handleDrop(index)}
                       >
                         <div className="flex items-center justify-between">
-                          <span className="text-sm text-muted-foreground">{song.file.name}</span>
+                          <span className="text-sm text-muted-foreground">
+                            {index + 1}. {song.file.name}
+                          </span>
                           <div className="flex items-center gap-2">
                             <button
                               type="button"


### PR DESCRIPTION
## Summary
- display track numbers next to each audio file when uploading album tracks

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68486c03f7488324b591d0cdddadff2f