### PR TITLE
Fix scrolling in client layout

### DIFF
--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -35,7 +35,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const showLayout = user && pathname !== '/login';
 
   return (
-    <div className="relative flex flex-col pb-28">
+    <div className="relative flex min-h-screen flex-col pb-28">
       {showLayout && (
         <header className="fixed inset-x-0 top-0 z-50 border-b border-border bg-background/75 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="container mx-auto flex items-center justify-between p-4">


### PR DESCRIPTION
## Summary
- restore `min-h-screen` to layout container to re-enable page scrolling

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488a6511d4832490baeb32812c3024