### PR TITLE
Improve search results with album track linking

### DIFF
--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { CalendarDays, ListMusic, Info, PlayCircle } from 'lucide-react';
@@ -40,6 +40,8 @@ interface Album {
 
 export default function AlbumPage() {
   const { albumId } = useParams();
+  const searchParams = useSearchParams();
+  const highlightedTrackId = searchParams.get('track');
   const [album, setAlbum] = useState<Album | null>(null);
   const [tracks, setTracks] = useState<Track[]>([]);
   const [mainArtists, setMainArtists] = useState<Artist[]>([]);
@@ -119,6 +121,14 @@ export default function AlbumPage() {
     setQueue(tracks);
     setIsPlaying(true);
   };
+
+  useEffect(() => {
+    if (!highlightedTrackId) return;
+    const el = document.getElementById(`track-${highlightedTrackId}`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlightedTrackId, tracks]);
 
   if (!album) return <div className="container mx-auto p-6 text-center">Loading album...</div>;
 
@@ -217,6 +227,8 @@ export default function AlbumPage() {
           {tracks.map((track) => (
             <TrackListItem
               key={track.id}
+              id={`track-${track.id}`}
+              highlight={track.id === highlightedTrackId}
               track={track}
               onPlay={handlePlayTrack}
               coverURL={album.coverURL}

--- a/src/components/AlbumCard.tsx
+++ b/src/components/AlbumCard.tsx
@@ -31,8 +31,9 @@ export function AlbumCard({ item, className }: { item: Track; className?: string
   const type = item.type === 'album' || item.albumId ? 'album' : 'single';
   const id = item.id;
 
-  // Generate the href dynamically based on type and id
-  const href = getTrackRoute({ type, id });
+  const href = item.albumId
+    ? `/album/${item.albumId}?track=${item.id}`
+    : getTrackRoute({ type, id });
 
   // Fetch whether the song is liked
   useEffect(() => {

--- a/src/components/music/TrackListItem.tsx
+++ b/src/components/music/TrackListItem.tsx
@@ -12,9 +12,11 @@ export type TrackListItemProps = {
   track: Track;
   onPlay: (track: Track) => void;
   coverURL?: string;
+  id?: string;
+  highlight?: boolean;
 };
 
-export default function TrackListItem({ track, onPlay, coverURL }: TrackListItemProps) {
+export default function TrackListItem({ track, onPlay, coverURL, id, highlight }: TrackListItemProps) {
   const currentTrack = usePlayerStore((s) => s.currentTrack);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const togglePlayPause = usePlayerStore((s) => s.togglePlayPause);
@@ -31,7 +33,8 @@ export default function TrackListItem({ track, onPlay, coverURL }: TrackListItem
 
   return (
     <div
-      className="group flex cursor-pointer items-center justify-between rounded px-2 py-1 transition hover:bg-muted"
+      id={id}
+      className={`group flex cursor-pointer items-center justify-between rounded px-2 py-1 transition hover:bg-muted ${highlight ? 'bg-muted' : ''}`}
       role="button"
       tabIndex={0}
       onClick={() => onPlay(track)}


### PR DESCRIPTION
## Summary
- include album tracks when searching
- allow TrackListItem to support highlighting for scrolling
- scroll to a track on the album page when visiting with `?track=`
- link search results for album tracks back to their album

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68489516f09883249879d9ad6f716dec