### PR TITLE
Fix player queue handling

### DIFF
--- a/src/app/album/[albumId]/page.tsx
+++ b/src/app/album/[albumId]/page.tsx
@@ -5,14 +5,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 import { CalendarDays, ListMusic, Info, PlayCircle } from 'lucide-react';
-import {
-  doc,
-  getDoc,
-  collection,
-  getDocs,
-  query,
-  where,
-} from 'firebase/firestore';
+import { doc, getDoc, collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { usePlayerStore } from '@/features/player/store';
 import type { Track, Artist } from '@/types/music';
@@ -66,7 +59,10 @@ export default function AlbumPage() {
 
           // Fetch main artists
           if (mainArtistIds.length > 0) {
-            const mainArtistQuery = query(collection(db, 'artists'), where('id', 'in', mainArtistIds));
+            const mainArtistQuery = query(
+              collection(db, 'artists'),
+              where('id', 'in', mainArtistIds)
+            );
             const mainArtistSnap = await getDocs(mainArtistQuery);
             fetchedMainArtists = mainArtistSnap.docs.map((doc) => ({
               id: doc.id,
@@ -110,6 +106,9 @@ export default function AlbumPage() {
   }, [albumId]);
 
   const handlePlayTrack = (track: Track) => {
+    if (tracks.length > 0) {
+      setQueue(tracks);
+    }
     setCurrentTrack(track);
     setIsPlaying(true);
   };

--- a/src/features/player/AudioProvider.tsx
+++ b/src/features/player/AudioProvider.tsx
@@ -18,6 +18,7 @@ export function AudioProvider() {
     setDuration,
     setProgress,
     skipToNext,
+    repeatMode,
   } = usePlayerStore();
   const { user } = useAuth();
 
@@ -97,7 +98,13 @@ export function AudioProvider() {
     if (currentTrack) {
       recordStream(user?.uid ?? null, { id: currentTrack.id, albumId: currentTrack.albumId });
     }
-    skipToNext();
+    if (repeatMode === 'one') {
+      // restart the current track
+      usePlayerStore.getState().seek(0);
+      usePlayerStore.setState({ isPlaying: true });
+    } else {
+      skipToNext();
+    }
   };
 
   return (

--- a/src/features/player/FullScreenPlayer.tsx
+++ b/src/features/player/FullScreenPlayer.tsx
@@ -23,7 +23,7 @@ import {
 } from 'lucide-react';
 
 export default function FullScreenPlayer() {
-  const [showQueue, setShowQueue] = useState(false); // State to toggle queue modal
+  const [showQueue, setShowQueue] = useState(false); // queue modal open state
   const {
     currentTrack,
     isPlaying,
@@ -101,7 +101,7 @@ export default function FullScreenPlayer() {
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => setShowQueue(!showQueue)} // Toggle queue modal
+          onClick={() => setShowQueue(true)}
           aria-label="View Queue"
         >
           <ListMusic size={20} />

--- a/src/features/player/store.ts
+++ b/src/features/player/store.ts
@@ -117,26 +117,72 @@ export const usePlayerStore = create<PlayerStore>()((set, get) => ({
   toggleShuffle: () => set((s) => ({ shuffleMode: !s.shuffleMode })), // Added implementation
 
   skipToNext: () => {
-    const { queue, queueIndex } = get();
-    const nextIndex = queueIndex + 1;
-    if (nextIndex < queue.length) {
-      set({
-        queueIndex: nextIndex,
-        currentTrack: queue[nextIndex],
-        isPlaying: true,
-      });
+    const { queue, queueIndex, shuffleMode, repeatMode } = get();
+
+    if (queue.length === 0) return;
+
+    let nextIndex = queueIndex + 1;
+
+    if (shuffleMode) {
+      // pick a random track different from the current
+      if (queue.length === 1) {
+        nextIndex = 0;
+      } else {
+        do {
+          nextIndex = Math.floor(Math.random() * queue.length);
+        } while (nextIndex === queueIndex);
+      }
+    } else if (nextIndex >= queue.length) {
+      if (repeatMode === 'all') {
+        nextIndex = 0;
+      } else {
+        // no more tracks and repeat is off
+        set({ isPlaying: false });
+        return;
+      }
     }
+
+    set({
+      queueIndex: nextIndex,
+      currentTrack: queue[nextIndex],
+      isPlaying: true,
+      currentTime: 0,
+      progress: 0,
+      duration: 0,
+    });
   },
 
   skipToPrev: () => {
-    const { queue, queueIndex } = get();
-    const prevIndex = queueIndex - 1;
-    if (prevIndex >= 0) {
-      set({
-        queueIndex: prevIndex,
-        currentTrack: queue[prevIndex],
-        isPlaying: true,
-      });
+    const { queue, queueIndex, shuffleMode, repeatMode } = get();
+
+    if (queue.length === 0) return;
+
+    let prevIndex = queueIndex - 1;
+
+    if (shuffleMode) {
+      if (queue.length === 1) {
+        prevIndex = 0;
+      } else {
+        do {
+          prevIndex = Math.floor(Math.random() * queue.length);
+        } while (prevIndex === queueIndex);
+      }
+    } else if (prevIndex < 0) {
+      if (repeatMode === 'all') {
+        prevIndex = queue.length - 1;
+      } else {
+        set({ isPlaying: false });
+        return;
+      }
     }
+
+    set({
+      queueIndex: prevIndex,
+      currentTrack: queue[prevIndex],
+      isPlaying: true,
+      currentTime: 0,
+      progress: 0,
+      duration: 0,
+    });
   },
 }));


### PR DESCRIPTION
## Summary
- autoplay queue respecting shuffle & repeat modes
- reset track queue on album track play
- keep queue modal stable on multiple taps

## Testing
- `npm run lint` *(fails: 2 errors)*
- `npm run typecheck`
- `npm run format:check` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_684a0126d5d48324b7e0c3196039ca30