### PR TITLE
Add basic admin CRUD pages

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,5 @@
+import Layout from '@/components/Layout';
+
+export default function AnalyticsPage() {
+  return <Layout>Analytics coming soon</Layout>;
+}

--- a/app/dashboard/artists/page.tsx
+++ b/app/dashboard/artists/page.tsx
@@ -1,5 +1,12 @@
-import Layout from '@/components/Layout'
+'use client';
+import Layout from '@/components/Layout';
+import ArtistsTable from '@/components/ArtistsTable';
 
 export default function ArtistsPage() {
-  return <Layout>Artists management coming soon</Layout>
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">Artists</h1>
+      <ArtistsTable />
+    </Layout>
+  );
 }

--- a/app/dashboard/playlists/page.tsx
+++ b/app/dashboard/playlists/page.tsx
@@ -1,5 +1,12 @@
-import Layout from '@/components/Layout'
+'use client';
+import Layout from '@/components/Layout';
+import PlaylistsTable from '@/components/PlaylistsTable';
 
 export default function PlaylistsPage() {
-  return <Layout>Playlists management coming soon</Layout>
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">Playlists</h1>
+      <PlaylistsTable />
+    </Layout>
+  );
 }

--- a/app/dashboard/users/page.tsx
+++ b/app/dashboard/users/page.tsx
@@ -1,5 +1,12 @@
-import Layout from '@/components/Layout'
+'use client';
+import Layout from '@/components/Layout';
+import UsersTable from '@/components/UsersTable';
 
 export default function UsersPage() {
-  return <Layout>Users management coming soon</Layout>
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">Users</h1>
+      <UsersTable />
+    </Layout>
+  );
 }

--- a/components/ArtistsTable.tsx
+++ b/components/ArtistsTable.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabaseAdmin } from '@/lib/supabase';
+
+export default function ArtistsTable() {
+  const [artists, setArtists] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = supabaseAdmin();
+      const { data } = await supabase.from('artists').select('*');
+      setArtists(data || []);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const addArtist = async () => {
+    if (!name) return;
+    setSaving(true);
+    const supabase = supabaseAdmin();
+    const { data, error } = await supabase.from('artists').insert({ name }).select().single();
+    if (!error && data) setArtists((a) => [...a, data]);
+    setName('');
+    setSaving(false);
+  };
+
+  if (loading) return <div>Loading artists...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Artist name"
+          className="flex-1 rounded border p-2"
+        />
+        <button
+          onClick={addArtist}
+          disabled={saving}
+          className="rounded bg-primary px-3 text-primary-foreground"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {artists.map((artist) => (
+          <li key={artist.id} className="border-b p-2">
+            {artist.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/PlaylistsTable.tsx
+++ b/components/PlaylistsTable.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabaseAdmin } from '@/lib/supabase';
+
+export default function PlaylistsTable() {
+  const [playlists, setPlaylists] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = supabaseAdmin();
+      const { data } = await supabase.from('playlists').select('*');
+      setPlaylists(data || []);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  const addPlaylist = async () => {
+    if (!name) return;
+    setSaving(true);
+    const supabase = supabaseAdmin();
+    const { data, error } = await supabase.from('playlists').insert({ name }).select().single();
+    if (!error && data) setPlaylists((p) => [...p, data]);
+    setName('');
+    setSaving(false);
+  };
+
+  if (loading) return <div>Loading playlists...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Playlist name"
+          className="flex-1 rounded border p-2"
+        />
+        <button
+          onClick={addPlaylist}
+          disabled={saving}
+          className="rounded bg-primary px-3 text-primary-foreground"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {playlists.map((pl) => (
+          <li key={pl.id} className="border-b p-2">
+            {pl.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,19 +1,20 @@
-'use client'
-import Link from 'next/link'
-import { useSupabaseAuth } from '@/contexts/SupabaseAuthProvider'
-import { usePathname } from 'next/navigation'
+'use client';
+import Link from 'next/link';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthProvider';
+import { usePathname } from 'next/navigation';
 
 const links = [
   { href: '/dashboard/upload', label: 'Upload' },
   { href: '/dashboard/users', label: 'Users' },
   { href: '/dashboard/artists', label: 'Artists' },
   { href: '/dashboard/playlists', label: 'Playlists' },
-]
+  { href: '/dashboard/analytics', label: 'Analytics' },
+];
 
 export default function Sidebar() {
-  const { isAdmin } = useSupabaseAuth()
-  const pathname = usePathname()
-  if (!isAdmin) return null
+  const { isAdmin } = useSupabaseAuth();
+  const pathname = usePathname();
+  if (!isAdmin) return null;
   return (
     <aside className="w-48 border-r border-border p-4 space-y-2">
       {links.map(({ href, label }) => (
@@ -29,5 +30,5 @@ export default function Sidebar() {
         </Link>
       ))}
     </aside>
-  )
+  );
 }

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -1,22 +1,43 @@
-'use client'
-import { useState } from 'react'
-import { supabaseAdmin } from '@/lib/supabase'
+'use client';
+import { useState } from 'react';
+import slugify from 'slugify';
+import { supabaseAdmin } from '@/lib/supabase';
 
 export default function UploadForm() {
-  const [title, setTitle] = useState('')
-  const [file, setFile] = useState<File | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [title, setTitle] = useState('');
+  const [audio, setAudio] = useState<File | null>(null);
+  const [cover, setCover] = useState<File | null>(null);
+  const [releaseDate, setReleaseDate] = useState('');
+  const [genre, setGenre] = useState('');
+  const [lyrics, setLyrics] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleUpload = async () => {
-    if (!file) return
-    setLoading(true)
-    const supabase = supabaseAdmin()
-    await supabase.storage.from('songs').upload(file.name, file)
-    await supabase.from('songs').insert({ title, file_path: file.name })
-    setLoading(false)
-    setTitle('')
-    setFile(null)
-  }
+    if (!audio || !cover || !title) return;
+    setLoading(true);
+    const supabase = supabaseAdmin();
+    const slug = slugify(title, { lower: true });
+    const audioPath = `${Date.now()}-${audio.name}`;
+    const coverPath = `${Date.now()}-${cover.name}`;
+    await supabase.storage.from('songs').upload(audioPath, audio);
+    await supabase.storage.from('covers').upload(coverPath, cover);
+    await supabase.from('tracks').insert({
+      title,
+      slug,
+      audio_path: audioPath,
+      cover_path: coverPath,
+      release_date: releaseDate || null,
+      genre,
+      lyrics,
+    });
+    setLoading(false);
+    setTitle('');
+    setAudio(null);
+    setCover(null);
+    setReleaseDate('');
+    setGenre('');
+    setLyrics('');
+  };
 
   return (
     <div className="space-y-2">
@@ -27,14 +48,34 @@ export default function UploadForm() {
         onChange={(e) => setTitle(e.target.value)}
         className="w-full rounded border p-2"
       />
-      <input type="file" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+      <input type="file" accept="audio/*" onChange={(e) => setAudio(e.target.files?.[0] ?? null)} />
+      <input type="file" accept="image/*" onChange={(e) => setCover(e.target.files?.[0] ?? null)} />
+      <input
+        type="date"
+        value={releaseDate}
+        onChange={(e) => setReleaseDate(e.target.value)}
+        className="w-full rounded border p-2"
+      />
+      <input
+        type="text"
+        placeholder="Genre"
+        value={genre}
+        onChange={(e) => setGenre(e.target.value)}
+        className="w-full rounded border p-2"
+      />
+      <textarea
+        placeholder="Lyrics"
+        value={lyrics}
+        onChange={(e) => setLyrics(e.target.value)}
+        className="w-full rounded border p-2"
+      />
       <button
         onClick={handleUpload}
         disabled={loading}
         className="rounded bg-primary px-4 py-2 text-primary-foreground"
       >
-        Upload
+        {loading ? 'Uploading...' : 'Upload'}
       </button>
     </div>
-  )
+  );
 }

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -1,0 +1,98 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabaseAdmin } from '@/lib/supabase';
+
+export default function UsersTable() {
+  const [users, setUsers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const supabase = supabaseAdmin();
+      const { data, error } = await (supabase as any).auth.admin.listUsers();
+      if (!error) setUsers(data.users);
+      setLoading(false);
+    };
+    fetchUsers();
+  }, []);
+
+  const updateRole = async (id: string, role: string) => {
+    setSavingId(id);
+    const supabase = supabaseAdmin();
+    await (supabase as any).auth.admin.updateUserById(id, { data: { role } });
+    setUsers((u) =>
+      u.map((user) =>
+        user.id === id ? { ...user, user_metadata: { ...user.user_metadata, role } } : user
+      )
+    );
+    setSavingId(null);
+  };
+
+  const deleteUser = async (id: string) => {
+    if (!confirm('Delete user?')) return;
+    const supabase = supabaseAdmin();
+    await (supabase as any).auth.admin.deleteUser(id);
+    setUsers((u) => u.filter((user) => user.id !== id));
+  };
+
+  const filtered = filter
+    ? users.filter((u) => (u.user_metadata?.role || 'listener') === filter)
+    : users;
+
+  if (loading) return <div>Loading users...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="rounded border p-2"
+        >
+          <option value="">All roles</option>
+          <option value="listener">Listener</option>
+          <option value="artist">Artist</option>
+          <option value="admin">Admin</option>
+        </select>
+      </div>
+      <table className="w-full table-auto border-collapse">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="p-2">Email</th>
+            <th className="p-2">Role</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((user) => (
+            <tr key={user.id} className="border-b">
+              <td className="p-2">{user.email}</td>
+              <td className="p-2">
+                <select
+                  value={user.user_metadata?.role || 'listener'}
+                  onChange={(e) => updateRole(user.id, e.target.value)}
+                  className="rounded border p-1 text-sm"
+                >
+                  <option value="listener">listener</option>
+                  <option value="artist">artist</option>
+                  <option value="admin">admin</option>
+                </select>
+                {savingId === user.id && <span className="ml-2 text-xs">Saving...</span>}
+              </td>
+              <td className="p-2">
+                <button
+                  onClick={() => deleteUser(user.id)}
+                  className="text-red-600 hover:underline"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "15.4.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "slugify": "^1.6.6",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -5817,6 +5818,15 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "15.4.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "slugify": "^1.6.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
## Summary
- extend upload form to handle audio, cover, metadata and slug creation
- add analytics page and link
- implement basic user, artist and playlist management tables
- wire new pages to dashboard sidebar
- include `slugify` dependency

## Testing
- `npm run lint` *(fails: eslint-plugin-tailwindcss missing)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6887661785988324bd4209d44423046e