### PR TITLE
Fix Next.js ESM setup

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: { appDir: true }
-}
+const nextConfig = {}
 
 export default nextConfig

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- remove the deprecated `appDir` option from `next.config.js`
- rewrite `postcss.config.js` to valid ESM

## Testing
- `npm run lint`
- `npm run build` *(fails: Supabase credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887697610f88324b78be9ac37219907