### PR TITLE
Add dashboard overview cards

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,68 @@
-import Layout from '@/components/Layout'
+import Layout from '@/components/Layout';
+import DashboardCard from '@/components/DashboardCard';
+import {
+  UploadCloud,
+  Users as UsersIcon,
+  User as ArtistIcon,
+  ListMusic,
+  BarChart2,
+  Settings as SettingsIcon,
+} from 'lucide-react';
+
+const cards = [
+  {
+    href: '/dashboard/upload',
+    title: 'Upload Music',
+    description: 'Add new tracks to the library',
+    icon: UploadCloud,
+  },
+  {
+    href: '/dashboard/artists',
+    title: 'Manage Artists',
+    description: 'View and edit artist profiles',
+    icon: ArtistIcon,
+  },
+  {
+    href: '/dashboard/users',
+    title: 'Manage Users',
+    description: 'Manage application users',
+    icon: UsersIcon,
+  },
+  {
+    href: '/dashboard/playlists',
+    title: 'Manage Playlists',
+    description: 'Organize user playlists',
+    icon: ListMusic,
+  },
+  {
+    href: '/dashboard/analytics',
+    title: 'Analytics',
+    description: 'View usage analytics',
+    icon: BarChart2,
+  },
+  {
+    href: '/dashboard/settings',
+    title: 'Settings',
+    description: 'Configure dashboard options',
+    icon: SettingsIcon,
+  },
+];
 
 export default function DashboardPage() {
-  return <Layout>Welcome to the dashboard</Layout>
+  return (
+    <Layout>
+      <div className="mx-auto max-w-7xl space-y-8">
+        <h1 className="text-4xl font-bold">Admin Dashboard</h1>
+        {cards.length ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {cards.map((card) => (
+              <DashboardCard key={card.href} {...card} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">Dashboard modules could not be loaded.</p>
+        )}
+      </div>
+    </Layout>
+  );
 }

--- a/components/DashboardCard.tsx
+++ b/components/DashboardCard.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { LucideIcon } from 'lucide-react';
+
+interface DashboardCardProps {
+  href: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export default function DashboardCard({
+  href,
+  title,
+  description,
+  icon: Icon,
+}: DashboardCardProps) {
+  return (
+    <Link
+      href={href}
+      className="rounded-lg border bg-card p-6 shadow-sm transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring"
+    >
+      <Icon className="h-6 w-6 text-muted-foreground" />
+      <h3 className="mt-4 text-lg font-semibold">{title}</h3>
+      <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- create `DashboardCard` component for linking to admin modules
- enhance `app/dashboard/page.tsx` with grid of admin cards

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68876da9e4408324bcea76a499860ef9