### PR TITLE
Refactor upload actions and improve dashboard forms

### DIFF
--- a/app/actions/upload.ts
+++ b/app/actions/upload.ts
@@ -1,8 +1,9 @@
+'use server'
+
 import slugify from 'slugify'
 import { supabaseAdmin } from '@/lib/supabase'
 
 export async function uploadSingleAction(formData: FormData) {
-  'use server'
   const supabase = supabaseAdmin()
   const title = formData.get('title') as string
   const artist = formData.get('artist') as string
@@ -10,6 +11,7 @@ export async function uploadSingleAction(formData: FormData) {
   const mood = formData.get('mood') as string
   const lyrics = formData.get('lyrics') as string
   const releaseDate = formData.get('releaseDate') as string
+  const albumId = formData.get('albumId') as string | null
   const audio = formData.get('audio') as File | null
   const cover = formData.get('cover') as File | null
   if (!audio || !cover) return
@@ -28,18 +30,22 @@ export async function uploadSingleAction(formData: FormData) {
     release_date: releaseDate || null,
     audio_path: audioPath,
     cover_path: coverPath,
+    album_id: albumId || null,
   })
 }
 
 export async function uploadAlbumAction(formData: FormData) {
-  'use server'
   const supabase = supabaseAdmin()
   const title = formData.get('title') as string
   const artist = formData.get('artist') as string
   const genre = formData.get('genre') as string
   const releaseDate = formData.get('releaseDate') as string
+  const description = formData.get('description') as string
   const cover = formData.get('cover') as File | null
-  const tracksMeta = JSON.parse(formData.get('tracks') as string) as { title: string; lyrics: string }[]
+  const tracksMeta = JSON.parse(formData.get('tracks') as string) as {
+    title: string
+    lyrics: string
+  }[]
   const files: File[] = tracksMeta.map((_, i) => formData.get(`file_${i}`) as File)
   if (!cover || files.some((f) => !f)) return
   const slug = slugify(title, { lower: true })
@@ -52,6 +58,7 @@ export async function uploadAlbumAction(formData: FormData) {
       slug,
       artist_name: artist,
       genre,
+      description,
       release_date: releaseDate || null,
       cover_path: coverPath,
     })

--- a/app/dashboard/upload/page.tsx
+++ b/app/dashboard/upload/page.tsx
@@ -4,8 +4,8 @@ import UploadTabs from '@/components/upload/UploadTabs'
 export default function UploadPage() {
   return (
     <Layout>
-      <div className="mx-auto max-w-3xl space-y-6">
-        <h1 className="text-2xl font-semibold tracking-tight">Upload Music</h1>
+      <div className="mx-auto w-full max-w-3xl space-y-6">
+        <h1 className="text-3xl font-semibold tracking-tight">Upload Music</h1>
         <UploadTabs />
       </div>
     </Layout>

--- a/components/upload/UploadAlbumForm.tsx
+++ b/components/upload/UploadAlbumForm.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useEffect, useState, useTransition } from 'react'
 import { supabaseBrowser } from '@/lib/supabase'
-import { uploadAlbumAction } from '@/app/dashboard/upload/actions'
+import { uploadAlbumAction } from '@/app/actions/upload'
+import { Image as ImageIcon, FileAudio, CalendarDays } from 'lucide-react'
 
 interface Artist { id: string; name: string }
 interface Track { title: string; file: File | null; lyrics: string }
@@ -13,6 +14,8 @@ export default function UploadAlbumForm() {
   const [cover, setCover] = useState<File | null>(null)
   const [releaseDate, setReleaseDate] = useState('')
   const [genre, setGenre] = useState('')
+  const [description, setDescription] = useState('')
+  const [albumId, setAlbumId] = useState('')
   const [tracks, setTracks] = useState<Track[]>([{ title: '', file: null, lyrics: '' }])
   const [pending, startTransition] = useTransition()
 
@@ -38,6 +41,8 @@ export default function UploadAlbumForm() {
     formData.append('title', title)
     formData.append('artist', artist)
     formData.append('genre', genre)
+    formData.append('description', description)
+    formData.append('albumId', albumId)
     formData.append('releaseDate', releaseDate)
     formData.append('cover', cover)
     formData.append('tracks', JSON.stringify(tracks.map(({ title, lyrics }) => ({ title, lyrics }))))
@@ -48,68 +53,163 @@ export default function UploadAlbumForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <input
-        required
-        type="text"
-        placeholder="Album title"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <input
-        list="artist-album-list"
-        placeholder="Main artist"
-        value={artist}
-        onChange={(e) => setArtist(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <datalist id="artist-album-list">
-        {artists.map((a) => (
-          <option key={a.id} value={a.name} />
-        ))}
-      </datalist>
-      <input
-        required
-        type="file"
-        accept="image/*"
-        onChange={(e) => setCover(e.target.files?.[0] || null)}
-      />
-      <input
-        type="date"
-        value={releaseDate}
-        onChange={(e) => setReleaseDate(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <input
-        type="text"
-        placeholder="Genre"
-        value={genre}
-        onChange={(e) => setGenre(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="relative">
+        <input
+          id="title"
+          required
+          placeholder=" "
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="title"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Album Title
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="artist"
+          list="artist-album-list"
+          placeholder=" "
+          value={artist}
+          onChange={(e) => setArtist(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="artist"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Artist
+        </label>
+        <datalist id="artist-album-list">
+          {artists.map((a) => (
+            <option key={a.id} value={a.name} />
+          ))}
+        </datalist>
+      </div>
+      <div>
+        <input
+          id="cover"
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => setCover(e.target.files?.[0] || null)}
+        />
+        <label
+          htmlFor="cover"
+          className="flex h-32 w-full cursor-pointer flex-col items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground"
+        >
+          {cover ? (
+            <span>{cover.name}</span>
+          ) : (
+            <span className="flex flex-col items-center gap-2"><ImageIcon className="h-6 w-6" /> Cover Image</span>
+          )}
+        </label>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="relative">
+          <input
+            id="genre"
+            placeholder=" "
+            value={genre}
+            onChange={(e) => setGenre(e.target.value)}
+            className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+          />
+          <label
+            htmlFor="genre"
+            className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+          >
+            Genre
+          </label>
+        </div>
+        <div className="relative">
+          <input
+            id="releaseDate"
+            type="date"
+            placeholder=" "
+            value={releaseDate}
+            onChange={(e) => setReleaseDate(e.target.value)}
+            className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+          />
+          <label
+            htmlFor="releaseDate"
+            className="absolute left-2 top-2 flex items-center gap-1 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+          >
+            <CalendarDays className="h-4 w-4" /> Release Date
+          </label>
+        </div>
+      </div>
+      <div className="relative">
+        <textarea
+          id="description"
+          placeholder=" "
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="description"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Description
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="albumId"
+          placeholder=" "
+          value={albumId}
+          onChange={(e) => setAlbumId(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="albumId"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Album ID
+        </label>
+      </div>
       <div className="space-y-2">
         {tracks.map((track, i) => (
           <div key={i} className="rounded-md bg-muted/50 p-3">
+            <div className="relative mb-2">
+              <input
+                id={`title_${i}`}
+                required
+                placeholder=" "
+                value={track.title}
+                onChange={(e) => updateTrack(i, 'title', e.target.value)}
+                className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+              />
+              <label
+                htmlFor={`title_${i}`}
+                className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+              >
+                Track Title
+              </label>
+            </div>
             <input
-              required
-              type="text"
-              placeholder="Track title"
-              value={track.title}
-              onChange={(e) => updateTrack(i, 'title', e.target.value)}
-              className="mb-2 w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-            />
-            <input
-              required
+              id={`file_${i}`}
               type="file"
               accept="audio/*"
+              hidden
               onChange={(e) => updateTrack(i, 'file', e.target.files?.[0] || null)}
             />
+            <label
+              htmlFor={`file_${i}`}
+              className="mb-2 flex cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed p-2 text-sm text-muted-foreground"
+            >
+              <FileAudio className="h-4 w-4" /> {track.file ? track.file.name : 'Audio File'}
+            </label>
             <textarea
               placeholder="Lyrics"
               value={track.lyrics}
               onChange={(e) => updateTrack(i, 'lyrics', e.target.value)}
-              className="mt-2 w-full rounded-md border bg-background/60 p-2 backdrop-blur"
+              className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
             />
           </div>
         ))}
@@ -119,7 +219,7 @@ export default function UploadAlbumForm() {
       </div>
       <button
         disabled={pending}
-        className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-all hover:opacity-90 disabled:opacity-50"
+        className="w-full rounded-md bg-primary px-4 py-2 text-primary-foreground transition-all hover:opacity-90 disabled:opacity-50"
       >
         {pending ? 'Uploading…' : 'Upload Album'}
       </button>

--- a/components/upload/UploadSingleForm.tsx
+++ b/components/upload/UploadSingleForm.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useEffect, useState, useTransition } from 'react'
 import { supabaseBrowser } from '@/lib/supabase'
-import { uploadSingleAction } from '@/app/dashboard/upload/actions'
+import { uploadSingleAction } from '@/app/actions/upload'
+import { Image as ImageIcon, FileAudio, CalendarDays } from 'lucide-react'
 
 interface Artist { id: string; name: string }
 
@@ -14,8 +15,10 @@ export default function UploadSingleForm() {
   const [audio, setAudio] = useState<File | null>(null)
   const [genre, setGenre] = useState('')
   const [mood, setMood] = useState('')
+  const [description, setDescription] = useState('')
   const [lyrics, setLyrics] = useState('')
   const [releaseDate, setReleaseDate] = useState('')
+  const [albumId, setAlbumId] = useState('')
   const [pending, startTransition] = useTransition()
 
   useEffect(() => {
@@ -35,87 +38,188 @@ export default function UploadSingleForm() {
     formData.append('artist', artist)
     formData.append('genre', genre)
     formData.append('mood', mood)
+    formData.append('description', description)
     formData.append('lyrics', lyrics)
     formData.append('releaseDate', releaseDate)
+    formData.append('albumId', albumId)
     formData.append('audio', audio)
     formData.append('cover', cover)
     startTransition(() => uploadSingleAction(formData))
   }
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      <input
-        required
-        type="text"
-        placeholder="Song title"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <input
-        list="artist-list"
-        placeholder="Artist name"
-        value={artist}
-        onChange={(e) => setArtist(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <datalist id="artist-list">
-        {artists.map((a) => (
-          <option key={a.id} value={a.name} />
-        ))}
-      </datalist>
-      <input
-        required
-        type="file"
-        accept="image/*"
-        onChange={(e) => {
-          const file = e.target.files?.[0] || null
-          setCover(file)
-          if (file) setCoverUrl(URL.createObjectURL(file))
-        }}
-      />
-      {coverUrl && (
-        <img
-          src={coverUrl}
-          alt="Preview"
-          className="h-32 w-32 rounded object-cover"
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="relative">
+        <input
+          id="title"
+          required
+          placeholder=" "
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
         />
-      )}
-      <input
-        required
-        type="file"
-        accept="audio/*"
-        onChange={(e) => setAudio(e.target.files?.[0] || null)}
-      />
-      <input
-        type="text"
-        placeholder="Genre"
-        value={genre}
-        onChange={(e) => setGenre(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <input
-        type="text"
-        placeholder="Mood (optional)"
-        value={mood}
-        onChange={(e) => setMood(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <textarea
-        placeholder="Lyrics"
-        value={lyrics}
-        onChange={(e) => setLyrics(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
-      <input
-        type="date"
-        value={releaseDate}
-        onChange={(e) => setReleaseDate(e.target.value)}
-        className="w-full rounded-md border bg-background/60 p-2 backdrop-blur"
-      />
+        <label
+          htmlFor="title"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Song Title
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="artist"
+          list="artist-list"
+          placeholder=" "
+          value={artist}
+          onChange={(e) => setArtist(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="artist"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Artist
+        </label>
+        <datalist id="artist-list">
+          {artists.map((a) => (
+            <option key={a.id} value={a.name} />
+          ))}
+        </datalist>
+      </div>
+      <div>
+        <input
+          id="cover"
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const file = e.target.files?.[0] || null
+            setCover(file)
+            if (file) setCoverUrl(URL.createObjectURL(file))
+          }}
+        />
+        <label
+          htmlFor="cover"
+          className="flex h-32 w-full cursor-pointer flex-col items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground"
+        >
+          {coverUrl ? (
+            <img src={coverUrl} alt="Preview" className="h-full w-full rounded object-cover" />
+          ) : (
+            <span className="flex flex-col items-center gap-2"><ImageIcon className="h-6 w-6" /> Drop cover image</span>
+          )}
+        </label>
+      </div>
+      <div>
+        <input
+          id="audio"
+          type="file"
+          accept="audio/*"
+          hidden
+          onChange={(e) => setAudio(e.target.files?.[0] || null)}
+        />
+        <label
+          htmlFor="audio"
+          className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+        >
+          <FileAudio className="h-5 w-5" /> {audio ? audio.name : 'Upload audio file'}
+        </label>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="relative">
+          <input
+            id="genre"
+            placeholder=" "
+            value={genre}
+            onChange={(e) => setGenre(e.target.value)}
+            className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+          />
+          <label
+            htmlFor="genre"
+            className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+          >
+            Genre
+          </label>
+        </div>
+        <div className="relative">
+          <input
+            id="mood"
+            placeholder=" "
+            value={mood}
+            onChange={(e) => setMood(e.target.value)}
+            className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+          />
+          <label
+            htmlFor="mood"
+            className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+          >
+            Mood
+          </label>
+        </div>
+      </div>
+      <div className="relative">
+        <textarea
+          id="description"
+          placeholder=" "
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="description"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Description
+        </label>
+      </div>
+      <div className="relative">
+        <textarea
+          id="lyrics"
+          placeholder=" "
+          value={lyrics}
+          onChange={(e) => setLyrics(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="lyrics"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Lyrics
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="releaseDate"
+          type="date"
+          placeholder=" "
+          value={releaseDate}
+          onChange={(e) => setReleaseDate(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="releaseDate"
+          className="absolute left-2 top-2 flex items-center gap-1 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          <CalendarDays className="h-4 w-4" /> Release Date
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="albumId"
+          placeholder=" "
+          value={albumId}
+          onChange={(e) => setAlbumId(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="albumId"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Album ID (optional)
+        </label>
+      </div>
       <button
         disabled={pending}
-        className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-all hover:opacity-90 disabled:opacity-50"
+        className="w-full rounded-md bg-primary px-4 py-2 text-primary-foreground transition-all hover:opacity-90 disabled:opacity-50"
       >
         {pending ? 'Uploading…' : 'Upload'}
       </button>

--- a/components/upload/UploadTabs.tsx
+++ b/components/upload/UploadTabs.tsx
@@ -3,6 +3,7 @@ import * as Tabs from '@radix-ui/react-tabs'
 import { motion } from 'framer-motion'
 import UploadSingleForm from './UploadSingleForm'
 import UploadAlbumForm from './UploadAlbumForm'
+import { Music, Album } from 'lucide-react'
 
 export default function UploadTabs() {
   return (
@@ -10,15 +11,15 @@ export default function UploadTabs() {
       <Tabs.List className="flex w-fit rounded-md bg-muted p-1 text-muted-foreground">
         <Tabs.Trigger
           value="single"
-          className="rounded-sm px-3 py-1 text-sm font-medium transition-all data-[state=active]:bg-background data-[state=active]:text-foreground"
+          className="flex items-center gap-1 rounded-sm px-3 py-1 text-sm font-medium transition-all data-[state=active]:bg-background data-[state=active]:text-foreground"
         >
-          Upload Single
+          <Music className="h-4 w-4" /> Single
         </Tabs.Trigger>
         <Tabs.Trigger
           value="album"
-          className="rounded-sm px-3 py-1 text-sm font-medium transition-all data-[state=active]:bg-background data-[state=active]:text-foreground"
+          className="flex items-center gap-1 rounded-sm px-3 py-1 text-sm font-medium transition-all data-[state=active]:bg-background data-[state=active]:text-foreground"
         >
-          Upload Album
+          <Album className="h-4 w-4" /> Album
         </Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value="single">


### PR DESCRIPTION
## Summary
- move server actions to `app/actions/upload.ts` with `use server`
- clean up upload page UI and use icons in tab navigation
- refactor single and album upload forms with floating labels and drag-drop areas
- route forms to new server actions

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68877280bb5c832497cce93f4083f448