### PR TITLE
Add admin dashboard pages

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,5 +1,20 @@
-import Layout from '@/components/Layout';
+import Layout from '@/components/Layout'
+import { motion } from 'framer-motion'
+import Skeleton from '@/components/Skeleton'
 
 export default function AnalyticsPage() {
-  return <Layout>Analytics coming soon</Layout>;
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">Analytics</h1>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-32" />
+        ))}
+      </motion.div>
+    </Layout>
+  )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -23,6 +23,12 @@ const cards = [
     icon: ArtistIcon,
   },
   {
+    href: '/dashboard/verify-artists',
+    title: 'Verify Artists',
+    description: 'Approve new artist accounts',
+    icon: ArtistIcon,
+  },
+  {
     href: '/dashboard/users',
     title: 'Manage Users',
     description: 'Manage application users',

--- a/app/dashboard/uploads/page.tsx
+++ b/app/dashboard/uploads/page.tsx
@@ -1,4 +1,11 @@
 import Layout from '@/components/Layout'
+import UploadsTable from '@/components/UploadsTable'
+
 export default function UploadsListPage() {
-  return <Layout>Your uploads will appear here.</Layout>
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">My Uploads</h1>
+      <UploadsTable />
+    </Layout>
+  )
 }

--- a/app/dashboard/verify-artists/page.tsx
+++ b/app/dashboard/verify-artists/page.tsx
@@ -1,0 +1,11 @@
+import Layout from '@/components/Layout'
+import VerifyArtistsTable from '@/components/VerifyArtistsTable'
+
+export default function VerifyArtistsPage() {
+  return (
+    <Layout>
+      <h1 className="mb-4 text-xl font-bold">Verify Artists</h1>
+      <VerifyArtistsTable />
+    </Layout>
+  )
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -7,6 +7,7 @@ const links = [
   { href: '/dashboard/upload', label: 'Upload' },
   { href: '/dashboard/users', label: 'Users' },
   { href: '/dashboard/artists', label: 'Artists' },
+  { href: '/dashboard/verify-artists', label: 'Verify Artists' },
   { href: '/dashboard/playlists', label: 'Playlists' },
   { href: '/dashboard/analytics', label: 'Analytics' },
 ];

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -1,0 +1,5 @@
+import clsx from 'clsx'
+
+export default function Skeleton({ className }: { className?: string }) {
+  return <div className={clsx('animate-pulse rounded-md bg-muted', className)} />
+}

--- a/components/UploadsTable.tsx
+++ b/components/UploadsTable.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { useEffect, useState } from 'react'
+import clsx from 'clsx'
+import { supabaseAdmin } from '@/lib/supabase'
+import Skeleton from './Skeleton'
+
+export default function UploadsTable() {
+  const [tracks, setTracks] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = supabaseAdmin()
+      const { data } = await supabase
+        .from('tracks')
+        .select('*')
+        .order('created_at', { ascending: false })
+      setTracks(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  if (loading)
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full" />
+        ))}
+      </div>
+    )
+
+  return (
+    <table className="w-full table-auto border-collapse">
+      <thead>
+        <tr className="border-b text-left">
+          <th className="p-2">Title</th>
+          <th className="p-2">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tracks.map((track) => (
+          <tr key={track.id} className="border-b">
+            <td className="p-2">{track.title}</td>
+            <td className="p-2">
+              <span
+                className={clsx(
+                  'rounded px-2 py-1 text-xs',
+                  track.is_published
+                    ? 'bg-green-600 text-white'
+                    : 'bg-muted text-muted-foreground',
+                )}
+              >
+                {track.is_published ? 'Published' : 'Draft'}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/components/VerifyArtistsTable.tsx
+++ b/components/VerifyArtistsTable.tsx
@@ -1,0 +1,93 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabaseAdmin } from '@/lib/supabase'
+import Skeleton from './Skeleton'
+import { Check, X } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { motion } from 'framer-motion'
+
+export default function VerifyArtistsTable() {
+  const [artists, setArtists] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = supabaseAdmin()
+      const { data } = await supabase.from('artists').select('*').eq('approved', false)
+      setArtists(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  const approve = async (id: string) => {
+    const supabase = supabaseAdmin()
+    await supabase.from('artists').update({ approved: true }).eq('id', id)
+    setArtists((a) => a.filter((ar) => ar.id !== id))
+  }
+
+  const reject = async (id: string) => {
+    const supabase = supabaseAdmin()
+    await supabase.from('artists').delete().eq('id', id)
+    setArtists((a) => a.filter((ar) => ar.id !== id))
+  }
+
+  if (loading)
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full" />
+        ))}
+      </div>
+    )
+
+  return (
+    <motion.table
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="w-full table-auto border-collapse"
+    >
+      <thead>
+        <tr className="border-b text-left">
+          <th className="p-2">Name</th>
+          <th className="p-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {artists.map((artist) => (
+          <tr key={artist.id} className="border-b">
+            <td className="p-2">{artist.name}</td>
+            <td className="p-2 space-x-2">
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <button
+                    onClick={() => approve(artist.id)}
+                    className="rounded bg-green-600 p-1 text-white hover:opacity-80"
+                  >
+                    <Check className="h-4 w-4" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content className="rounded bg-muted px-2 py-1 text-xs">
+                  Approve
+                </Tooltip.Content>
+              </Tooltip.Root>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <button
+                    onClick={() => reject(artist.id)}
+                    className="rounded bg-red-600 p-1 text-white hover:opacity-80"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content className="rounded bg-muted px-2 py-1 text-xs">
+                  Reject
+                </Tooltip.Content>
+              </Tooltip.Root>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </motion.table>
+  )
+}

--- a/components/upload/UploadSingleForm.tsx
+++ b/components/upload/UploadSingleForm.tsx
@@ -20,6 +20,9 @@ export default function UploadSingleForm() {
   const [lyrics, setLyrics] = useState('')
   const [releaseDate, setReleaseDate] = useState('')
   const [albumId, setAlbumId] = useState('')
+  const [featuredArtists, setFeaturedArtists] = useState('')
+  const [language, setLanguage] = useState('')
+  const [duration, setDuration] = useState('')
   const [published, setPublished] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [pending, startTransition] = useTransition()
@@ -43,8 +46,11 @@ export default function UploadSingleForm() {
     formData.append('mood', mood)
     formData.append('description', description)
     formData.append('lyrics', lyrics)
+    formData.append('duration', duration)
     formData.append('releaseDate', releaseDate)
     formData.append('albumId', albumId)
+    formData.append('featured', featuredArtists)
+    formData.append('language', language)
     formData.append('published', published ? 'on' : '')
     formData.append('audio', audio)
     formData.append('cover', cover)
@@ -60,6 +66,9 @@ export default function UploadSingleForm() {
         setLyrics('')
         setReleaseDate('')
         setAlbumId('')
+        setFeaturedArtists('')
+        setLanguage('')
+        setDuration('')
         setAudio(null)
         setCover(null)
         setCoverUrl(null)
@@ -130,6 +139,21 @@ export default function UploadSingleForm() {
           ))}
         </datalist>
       </div>
+      <div className="relative">
+        <input
+          id="featured"
+          placeholder=" "
+          value={featuredArtists}
+          onChange={(e) => setFeaturedArtists(e.target.value)}
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="featured"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Featured Artists
+        </label>
+      </div>
       <div>
         <input
           id="cover"
@@ -157,15 +181,40 @@ export default function UploadSingleForm() {
         <input
           id="audio"
           type="file"
-          accept="audio/*"
+          accept="audio/mpeg"
           hidden
-          onChange={(e) => setAudio(e.target.files?.[0] || null)}
+          onChange={(e) => {
+            const file = e.target.files?.[0] || null
+            setAudio(file)
+            if (file) {
+              const audioEl = document.createElement('audio')
+              audioEl.src = URL.createObjectURL(file)
+              audioEl.addEventListener('loadedmetadata', () => {
+                setDuration(Math.round(audioEl.duration).toString())
+              })
+            }
+          }}
         />
         <label
           htmlFor="audio"
           className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground"
         >
           <FileAudio className="h-5 w-5" /> {audio ? audio.name : 'Upload audio file'}
+        </label>
+      </div>
+      <div className="relative">
+        <input
+          id="duration"
+          placeholder=" "
+          value={duration}
+          readOnly
+          className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+        />
+        <label
+          htmlFor="duration"
+          className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+        >
+          Duration (sec)
         </label>
       </div>
       <div className="grid grid-cols-2 gap-4">
@@ -197,6 +246,21 @@ export default function UploadSingleForm() {
             className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
           >
             Mood
+          </label>
+        </div>
+        <div className="relative">
+          <input
+            id="language"
+            placeholder=" "
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="peer w-full rounded-md border bg-background/60 p-2 pt-6 backdrop-blur"
+          />
+          <label
+            htmlFor="language"
+            className="absolute left-2 top-2 text-xs text-muted-foreground transition-all peer-placeholder-shown:top-4 peer-placeholder-shown:text-sm peer-focus:top-2 peer-focus:text-xs"
+          >
+            Language
           </label>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-tooltip": "^1.2.7",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.52.1",
         "clsx": "^2.1.1",
@@ -1652,6 +1653,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.7.tgz",
+      "integrity": "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -1769,6 +1804,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.52.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add skeleton loader component
- create tables for uploads and artist verification
- flesh out admin pages for uploads, verify artists and analytics
- update sidebar and dashboard links
- extend single upload form with duration, language and featured artists
- include @radix-ui/react-tooltip dependency

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6887962aac5883249e40087c965f8db9